### PR TITLE
DTD-1153: Moves test-only endpoints to testOnlyDoNotUseInAppConf

### DIFF
--- a/conf/app.routes
+++ b/conf/app.routes
@@ -4,9 +4,3 @@ POST       /quote                                   uk.gov.hmrc.timetopayproxy.c
 GET        /quote/:customerReference/:planId        uk.gov.hmrc.timetopayproxy.controllers.TimeToPayProxyController.viewPlan(customerReference: String, planId: String)
 PUT        /quote/:customerReference/:planId        uk.gov.hmrc.timetopayproxy.controllers.TimeToPayProxyController.updatePlan(customerReference: String, planId: String)
 POST       /quote/arrangement                       uk.gov.hmrc.timetopayproxy.controllers.TimeToPayProxyController.createPlan
-
-GET        /test-only/requests                      uk.gov.hmrc.timetopayproxy.controllers.TimeToPayTestController.requests
-POST       /test-only/response                      uk.gov.hmrc.timetopayproxy.controllers.TimeToPayTestController.response
-DELETE     /test-only/request/:requestId            uk.gov.hmrc.timetopayproxy.controllers.TimeToPayTestController.deleteRequest(requestId: String)
-GET        /test-only/errors                        uk.gov.hmrc.timetopayproxy.controllers.TimeToPayTestController.getErrors
-POST       /test-only/errors                        uk.gov.hmrc.timetopayproxy.controllers.TimeToPayTestController.saveError

--- a/conf/testOnlyDoNotUseInAppConf.routes
+++ b/conf/testOnlyDoNotUseInAppConf.routes
@@ -10,4 +10,11 @@
 # Failing to follow this rule may result in test routes deployed in production.
 
 # Add all the application routes to the prod.routes file
+
+GET        /test-only/requests                      uk.gov.hmrc.timetopayproxy.controllers.TimeToPayTestController.requests
+POST       /test-only/response                      uk.gov.hmrc.timetopayproxy.controllers.TimeToPayTestController.response
+DELETE     /test-only/request/:requestId            uk.gov.hmrc.timetopayproxy.controllers.TimeToPayTestController.deleteRequest(requestId: String)
+GET        /test-only/errors                        uk.gov.hmrc.timetopayproxy.controllers.TimeToPayTestController.getErrors
+POST       /test-only/errors                        uk.gov.hmrc.timetopayproxy.controllers.TimeToPayTestController.saveError
+
 ->         /                          prod.Routes


### PR DESCRIPTION
test-only endpoints should not be exposed in prod, this allows them to be exposed in ET and not in prod