### PR TITLE
DTD-1237: Adds Collections to response and updates raml

### DIFF
--- a/app/uk/gov/hmrc/timetopayproxy/models/Collections.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/models/Collections.scala
@@ -16,24 +16,24 @@
 
 package uk.gov.hmrc.timetopayproxy.models
 
-import java.time.LocalDate
-
 import play.api.libs.json.Json
 
-final case class GenerateQuoteResponse(
-  quoteReference: QuoteReference,
-  customerReference: CustomerReference,
-  quoteType: QuoteType,
-  quoteDate: LocalDate,
-  numberOfInstalments: Int,
-  totalDebtIncInt: BigDecimal,
-  interestAccrued: BigDecimal,
-  planInterest: BigDecimal,
-  totalInterest: BigDecimal,
-  instalments: List[Instalment],
-  collections: Collections
-)
+import java.time.LocalDate
 
-object GenerateQuoteResponse {
-  implicit val format = Json.format[GenerateQuoteResponse]
+final case class InitialCollection(dueDate: LocalDate, amountDue: BigDecimal)
+
+object InitialCollection {
+  implicit val format = Json.format[InitialCollection]
+}
+
+final case class RegularCollection(dueDate: LocalDate, amountDue: BigDecimal)
+
+object RegularCollection {
+  implicit val format = Json.format[RegularCollection]
+}
+
+final case class Collections(initialCollection: Option[InitialCollection], regularCollections: List[RegularCollection])
+
+object Collections {
+  implicit val format = Json.format[Collections]
 }

--- a/resources/public/api/conf/1.0/examples/generate/postGenerateResponse.json
+++ b/resources/public/api/conf/1.0/examples/generate/postGenerateResponse.json
@@ -8,16 +8,45 @@
   "interestAccrued": 10,
   "planInterest": 0.25,
   "totalInterest": 12.25,
-  "instalments": [
-    {
-      "debtItemChargeId": "debtChargeId1",
-      "dueDate": "2021-05-13",
-      "amountDue": 100,
-      "expectedPayment": 100,
-      "interestRate": 0.24,
-      "instalmentNumber": 1,
-      "instalmentInterestAccrued": 10,
-      "instalmentBalance": 10
-    }
-  ]
+  "instalments": [{
+    "debtItemChargeId": "debtItemChargeId1",
+    "dueDate": "2021-05-13",
+    "amountDue": 100,
+    "expectedPayment": 100,
+    "interestRate": 0.24,
+    "instalmentNumber": 1,
+    "instalmentInterestAccrued": 10,
+    "instalmentBalance": 10
+  }, {
+    "debtItemChargeId": "debtItemChargeId2",
+    "dueDate": "2021-05-13",
+    "amountDue": 100,
+    "expectedPayment": 100,
+    "interestRate": 0.24,
+    "instalmentNumber": 1,
+    "instalmentInterestAccrued": 10,
+    "instalmentBalance": 10
+  }, {
+    "debtItemChargeId": "debtItemChargeId3",
+    "dueDate": "2021-05-13",
+    "amountDue": 100,
+    "expectedPayment": 100,
+    "interestRate": 0.24,
+    "instalmentNumber": 1,
+    "instalmentInterestAccrued": 10,
+    "instalmentBalance": 10
+  }],
+  "collections": {
+    "initialCollection": {
+      "dueDate": "2022-06-18",
+      "amountDue": 1000
+    },
+    "regularCollections": [{
+      "dueDate": "2022-07-08",
+      "amountDue": 1628.21
+    }, {
+      "dueDate": "2022-08-08",
+      "amountDue": 1628.21
+    }]
+  }
 }

--- a/resources/public/api/conf/1.0/schemas/generate/postGenerateResponseSchema.json
+++ b/resources/public/api/conf/1.0/schemas/generate/postGenerateResponseSchema.json
@@ -17,10 +17,7 @@
     },
     "quoteType": {
       "type": "string",
-      "enum": [
-        "duration",
-        "instalmentAmount"
-      ],
+      "enum": ["duration", "instalmentAmount"],
       "description": "this will determine what IFS is required to calculate either duration or instalment amount"
     },
     "quoteDate": {
@@ -50,48 +47,82 @@
     },
     "instalments": {
       "type": "array",
-      "items": [
-        {
+      "items": [{
+        "type": "object",
+        "properties": {
+          "debtItemChargeId": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 16,
+            "description": "An ID which uniquely identifies a particular duty"
+          },
+          "dueDate": {
+            "type": "string",
+            "format": "date",
+            "description": "Due date"
+          },
+          "amountDue": {
+            "type": "integer",
+            "description": "Amount due"
+          },
+          "expectedPayment": {
+            "type": "integer",
+            "description": "Expected payment"
+          },
+          "interestRate": {
+            "type": "number",
+            "description": "Interest rate"
+          },
+          "instalmentNumber": {
+            "type": "integer",
+            "description": "Instalment number"
+          },
+          "instalmentInterestAccrued": {
+            "type": "integer",
+            "description": "Instalment interest"
+          },
+          "instalmentBalance": {
+            "type": "integer",
+            "description": "Instalment balance"
+          }
+        }
+      }]
+    },
+    "collections": {
+      "type": "object",
+      "properties": {
+        "initialCollection": {
           "type": "object",
           "properties": {
-            "dedbtItemChargeId": {
-              "type": "string",
-              "minLength": 1,
-              "maxLength": 16,
-              "description": "An ID which uniquely identifies a particular duty"
-            },
             "dueDate": {
               "type": "string",
               "format": "date",
               "description": "Due date"
             },
             "amountDue": {
-              "type": "integer",
-              "description": "Amount due"
-            },
-            "expectedPayment": {
-              "type": "integer",
-              "description": "Expected payment"
-            },
-            "interestRate": {
               "type": "number",
-              "description": "Interest rate"
-            },
-            "instalmentNumber": {
-              "type": "integer",
-              "description": "Instalment number"
-            },
-            "instalmentInterestAccrued": {
-              "type": "integer",
-              "description": "Instalment interest"
-            },
-            "instalmentBalance": {
-              "type": "integer",
-              "description": "Instalment balance"
+              "description": "Amount due"
+            }
+          }
+        },
+        "regularCollections": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "dueDate": {
+                "type": "string",
+                "format": "date",
+                "description": "Due date"
+              },
+              "amountDue": {
+                "type": "number",
+                "description": "Amount due"
+              }
             }
           }
         }
-      ]
+      }
     }
   }
 }

--- a/test/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyControllerSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyControllerSpec.scala
@@ -56,15 +56,15 @@ class TimeToPayProxyControllerSpec extends AnyWordSpec with Matchers with MockFa
     CustomerReference("customerReference"),
     ChannelIdentifier.Advisor,
     PlanToGenerateQuote(
-      QuoteType.Duration,
-      LocalDate.of(2021, 1, 1),
-      LocalDate.of(2021, 1, 1),
-      Some(1),
-      Some(Frequency.Annually),
-      Some(Duration(12)),
-      Some(1),
-      Some(LocalDate.now()),
-      PaymentPlanType.TimeToPay
+      quoteType = QuoteType.Duration,
+      quoteDate = LocalDate.of(2021, 1, 1),
+      instalmentStartDate = LocalDate.of(2021, 1, 1),
+      instalmentAmount = Some(1),
+      frequency = Some(Frequency.Annually),
+      duration = Some(Duration(12)),
+      initialPaymentAmount = Some(1),
+      initialPaymentDate = Some(LocalDate.now()),
+      paymentPlanType = PaymentPlanType.TimeToPay
     ),
     List(),
     List()
@@ -215,17 +215,21 @@ class TimeToPayProxyControllerSpec extends AnyWordSpec with Matchers with MockFa
           0.9,
           List(
             Instalment(
-              DebtItemChargeId("dutyId"),
-              LocalDate.parse("2022-01-01"),
-              100,
-              100,
-              0.1,
-              1,
-              0.5,
-              10
+              debtItemChargeId = DebtItemChargeId("dutyId"),
+              dueDate = LocalDate.parse("2022-01-01"),
+              amountDue = 100,
+              expectedPayment = 100,
+              interestRate = 0.1,
+              instalmentNumber = 1,
+              instalmentInterestAccrued = 0.5,
+              instalmentBalance = 10
             )
-          )
+          ),
+          Collections(
+            Some(InitialCollection(LocalDate.now(), 1)),
+            List(RegularCollection(LocalDate.parse("2022-01-01"), 100)))
         )
+
         (ttpQuoteService
           .generateQuote(_: GenerateQuoteRequest)(
             _: ExecutionContext,
@@ -489,8 +493,7 @@ class TimeToPayProxyControllerSpec extends AnyWordSpec with Matchers with MockFa
           FakeRequest(
             "PUT",
             s"/individuals/time-to-pay/quote/${updatePlanRequestMissingPaymentReference.customerReference.value}/${updatePlanRequestMissingPaymentReference.planId.value}"
-          )
-            .withHeaders(CONTENT_TYPE -> MimeTypes.JSON)
+          ).withHeaders(CONTENT_TYPE -> MimeTypes.JSON)
             .withBody(Json.toJson(updatePlanRequestMissingPaymentReference))
 
         val responseFromTtp = UpdatePlanResponse(
@@ -551,8 +554,7 @@ class TimeToPayProxyControllerSpec extends AnyWordSpec with Matchers with MockFa
           FakeRequest(
             "PUT",
             s"/individuals/time-to-pay/quote/${updatePlanRequestMissingPlanStatus.customerReference.value}/${updatePlanRequestMissingPlanStatus.planId.value}"
-          )
-            .withHeaders(CONTENT_TYPE -> MimeTypes.JSON)
+          ).withHeaders(CONTENT_TYPE -> MimeTypes.JSON)
             .withBody(Json.toJson(updatePlanRequestMissingPlanStatus))
 
         val responseFromTtp = UpdatePlanResponse(
@@ -705,8 +707,7 @@ class TimeToPayProxyControllerSpec extends AnyWordSpec with Matchers with MockFa
           FakeRequest(
             "PUT",
             s"/individuals/time-to-pay/quote/customerRef1234/planId1234"
-          )
-            .withHeaders(CONTENT_TYPE -> MimeTypes.JSON)
+          ).withHeaders(CONTENT_TYPE -> MimeTypes.JSON)
             .withBody(invalidJsonBody)
 
         val response: Future[Result] =
@@ -754,8 +755,7 @@ class TimeToPayProxyControllerSpec extends AnyWordSpec with Matchers with MockFa
           FakeRequest(
             "PUT",
             s"/individuals/time-to-pay/quote/customerRef1234/planId1234"
-          )
-            .withHeaders(CONTENT_TYPE -> MimeTypes.JSON)
+          ).withHeaders(CONTENT_TYPE -> MimeTypes.JSON)
             .withBody(invalidJsonBody)
 
         val response: Future[Result] =
@@ -804,8 +804,7 @@ class TimeToPayProxyControllerSpec extends AnyWordSpec with Matchers with MockFa
           FakeRequest(
             "PUT",
             s"/individuals/time-to-pay/quote/customerRef1234/planId1234"
-          )
-            .withHeaders(CONTENT_TYPE -> MimeTypes.JSON)
+          ).withHeaders(CONTENT_TYPE -> MimeTypes.JSON)
             .withBody(invalidJsonBody)
 
         val response: Future[Result] =
@@ -845,8 +844,7 @@ class TimeToPayProxyControllerSpec extends AnyWordSpec with Matchers with MockFa
           FakeRequest(
             "PUT",
             s"/individuals/time-to-pay/quote/custReference1234/planId1234"
-          )
-            .withHeaders(CONTENT_TYPE -> MimeTypes.JSON)
+          ).withHeaders(CONTENT_TYPE -> MimeTypes.JSON)
             .withBody(invalidJsonBody)
 
         val response: Future[Result] =

--- a/test/uk/gov/hmrc/timetopayproxy/models/GenerateQuoteResponseSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/models/GenerateQuoteResponseSpec.scala
@@ -44,6 +44,12 @@ class GenerateQuoteResponseSpec extends AnyWordSpec with Matchers {
         10,
         10
       )
+    ),
+    Collections(
+      Some(InitialCollection(LocalDate.parse("2022-06-18"), 1000)),
+      List(
+        RegularCollection(LocalDate.parse("2022-07-08"), 1628.21),
+        RegularCollection(LocalDate.parse("2022-08-08"), 1628.21))
     )
   )
 
@@ -68,8 +74,20 @@ class GenerateQuoteResponseSpec extends AnyWordSpec with Matchers {
                |      "instalmentInterestAccrued": 10,
                |      "instalmentBalance": 10
                |    }
-               |  ]
-               |
+               |  ],
+               | "collections": {
+               |    "initialCollection": {
+               |      "dueDate": "2022-06-18",
+               |      "amountDue": 1000
+               |    },
+               |    "regularCollections": [{
+               |      "dueDate": "2022-07-08",
+               |      "amountDue": 1628.21
+               |    }, {
+               |      "dueDate": "2022-08-08",
+               |      "amountDue": 1628.21
+               |    }]
+               |  }
                |}""".stripMargin
 
   "GenerateQuoteResponse" should {

--- a/test/uk/gov/hmrc/timetopayproxy/services/TTPQuoteServiceSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/services/TTPQuoteServiceSpec.scala
@@ -71,7 +71,10 @@ class TTPQuoteServiceSpec extends UnitSpec {
         0.5,
         50
       )
-    )
+    ),
+    Collections(
+      Some(InitialCollection(LocalDate.now(), 1)),
+      List(RegularCollection(LocalDate.parse("2022-01-01"), 100)))
   )
 
   private val retrievePlanResponse = ViewPlanResponse(
@@ -391,27 +394,27 @@ class TtpConnectorStub(
   updatePlanResponse: Either[TtppError, UpdatePlanResponse],
   createPlanResponse: Either[TtppError, CreatePlanResponse]
 ) extends TtpConnector {
-  override def generateQuote(ttppRequest: GenerateQuoteRequest)(implicit
+  override def generateQuote(ttppRequest: GenerateQuoteRequest)(
+    implicit
     ec: ExecutionContext,
-    hc: HeaderCarrier
-  ): TtppEnvelope[GenerateQuoteResponse] =
+    hc: HeaderCarrier): TtppEnvelope[GenerateQuoteResponse] =
     TtppEnvelope(Future successful generateQuoteResponse)
 
-  override def getExistingQuote(customerReference: CustomerReference, planId: PlanId)(implicit
+  override def getExistingQuote(customerReference: CustomerReference, planId: PlanId)(
+    implicit
     ec: ExecutionContext,
-    hc: HeaderCarrier
-  ): TtppEnvelope[ViewPlanResponse] =
+    hc: HeaderCarrier): TtppEnvelope[ViewPlanResponse] =
     TtppEnvelope(Future successful retrieveQuoteResponse)
 
-  override def updatePlan(updatePlanRequest: UpdatePlanRequest)(implicit
+  override def updatePlan(updatePlanRequest: UpdatePlanRequest)(
+    implicit
     ec: ExecutionContext,
-    hc: HeaderCarrier
-  ): TtppEnvelope[UpdatePlanResponse] =
+    hc: HeaderCarrier): TtppEnvelope[UpdatePlanResponse] =
     TtppEnvelope(Future successful updatePlanResponse)
 
-  override def createPlan(createPlanRequest: CreatePlanRequest)(implicit
+  override def createPlan(createPlanRequest: CreatePlanRequest)(
+    implicit
     ec: ExecutionContext,
-    hc: HeaderCarrier
-  ): TtppEnvelope[CreatePlanResponse] =
+    hc: HeaderCarrier): TtppEnvelope[CreatePlanResponse] =
     TtppEnvelope(Future successful createPlanResponse)
 }


### PR DESCRIPTION
As the DM user

I need the TTP returned with payments

So that it shows the payments as the customer would pay them (currently instalments only are returned)

TTP now want us to return payment collections the same as we provide for SS TTP.

Paired with -> https://github.com/hmrc/time-to-pay/pull/76