### PR TITLE
NO-JIRA: sets client request timeout to 120s to support long lived IF…

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -19,6 +19,10 @@ include "backend.conf"
 
 appName = time-to-pay-proxy
 
+
+play.ws.timeout.request = 120s
+
+
 # An ApplicationLoader that uses Guice to bootstrap the application.
 play.application.loader = "uk.gov.hmrc.play.bootstrap.ApplicationLoader"
 


### PR DESCRIPTION
NO-JIRA: sets client request timeout to 120s to support long lived IFS calls 