### PR TITLE
DTD-1434 Safely convert string to PlanStatus in time-to-pay-proxy

### DIFF
--- a/app/uk/gov/hmrc/timetopayproxy/models/CreatePlanResponse.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/models/CreatePlanResponse.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.timetopayproxy.models
 
 import enumeratum.{ Enum, EnumEntry, PlayJsonEnum }
 import play.api.libs.json.Json
+import uk.gov.hmrc.timetopayproxy.models.error.PlanStatusCreateError
 
 final case class CaseId(value: String) extends AnyVal
 
@@ -47,7 +48,10 @@ object PlanStatus extends Enum[PlanStatus] with PlayJsonEnum[PlanStatus] {
   case object MonitoringSuspended extends PlanStatus("TTP - Monitoring suspended")
   case object PendingCancellationLetter extends PlanStatus("Pending - Cancellation Letter")
 
-  def valueOf(value: String): Option[PlanStatus] = PlanStatus.withNameInsensitiveOption(value)
+  def valueOf(value: String): Either[PlanStatusCreateError, PlanStatus] =
+    PlanStatus
+      .withNameInsensitiveOption(value)
+      .toRight(PlanStatusCreateError(s"Failed to create plan status from $value"))
 
 }
 

--- a/app/uk/gov/hmrc/timetopayproxy/models/error/PlanStatusCreateError.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/models/error/PlanStatusCreateError.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.timetopayproxy.models.error
+
+import play.api.libs.json.{Json, OFormat}
+import uk.gov.hmrc.timetopayproxy.models.TtppError
+
+final case class PlanStatusCreateError(description: String) extends TtppError
+
+object PlanStatusCreateError {
+  implicit val format: OFormat[PlanStatusCreateError] = Json.format[PlanStatusCreateError]
+}

--- a/app/uk/gov/hmrc/timetopayproxy/models/error/PlanStatusCreateError.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/models/error/PlanStatusCreateError.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.timetopayproxy.models.error
 
-import play.api.libs.json.{Json, OFormat}
+import play.api.libs.json.{ Json, OFormat }
 import uk.gov.hmrc.timetopayproxy.models.TtppError
 
 final case class PlanStatusCreateError(description: String) extends TtppError


### PR DESCRIPTION
Just as was done in the [time-to-pay](https://github.com/hmrc/time-to-pay/blob/main/app/uk/gov/hmrc/timetopay/models/common/PlanStatus.scala#L32-L35) service, this PR safely converts a given string to the `PlanStatus` enum.