### PR TITLE
DTD-2507: Remove unused loggers reported by problem bot.

### DIFF
--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -14,19 +14,6 @@
         </encoder>
     </appender>
 
-    <appender name="STDOUT_IGNORE_NETTY" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] rid=[not-available] user=[not-available] message=[%message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
-        </encoder>
-    </appender>
-
-    <appender name="ACCESS_LOG_FILE" class="ch.qos.logback.core.FileAppender">
-        <file>logs/access.log</file>
-        <encoder>
-            <pattern>%message%n</pattern>
-        </encoder>
-    </appender>
-
     <appender name="CONNECTOR_LOG_FILE" class="ch.qos.logback.core.FileAppender">
         <file>logs/connector.log</file>
         <encoder>
@@ -34,14 +21,6 @@
         </encoder>
     </appender>
 
-
-    <logger name="accesslog" level="INFO" additivity="false">
-        <appender-ref ref="ACCESS_LOG_FILE" />
-    </logger>
-
-    <logger name="com.ning.http.client.providers.netty" additivity="false">
-        <appender-ref ref="STDOUT_IGNORE_NETTY" />
-    </logger>
 
     <logger name="com.google.inject" level="INFO"/>
 


### PR DESCRIPTION
This PR came in a set of six:
- https://github.com/hmrc/debt-transformation-stub/pull/199
- https://github.com/hmrc/time-to-pay-eligibility/pull/172
- https://github.com/hmrc/interest-forecasting/pull/344
- https://github.com/hmrc/time-to-pay/pull/270
- https://github.com/hmrc/statement-of-liability/pull/102
- https://github.com/hmrc/time-to-pay-proxy/pull/108

It's intended to resolve these PR bot prompts:
> - `STDOUT_IGNORE_NETTY` appender (and usage) can be removed from [conf/logback.xml](https://github.com/hmrc/debt-transformation-stub/blob/DTD-2352/conf/logback.xml#L17) - Netty server is no longer used (Since Play 2.6.x)
> - `ACCESS_LOG_FILE` appender (and usage) can be removed from [conf/logback.xml](https://github.com/hmrc/debt-transformation-stub/blob/DTD-2352/conf/logback.xml#L23) - it's never populated

Examples:
- https://github.com/hmrc/debt-transformation-stub/pull/198#issuecomment-2163162325
- https://github.com/hmrc/time-to-pay-eligibility/pull/171#issuecomment-2175934396
- https://github.com/hmrc/interest-forecasting/pull/343#issuecomment-2162579594
- https://github.com/hmrc/time-to-pay/pull/271#issuecomment-2176124507
- https://github.com/hmrc/statement-of-liability/pull/101#issuecomment-2152031747
- https://github.com/hmrc/time-to-pay-proxy/pull/109#issuecomment-2176126486
