### PR TITLE
DTD-2834: Remove scopes from API definition - TTP-proxy

### DIFF
--- a/it/test/uk/gov/hmrc/timetopayproxy/config/DocumentationSpec.scala
+++ b/it/test/uk/gov/hmrc/timetopayproxy/config/DocumentationSpec.scala
@@ -26,13 +26,6 @@ class DocumentationControllerSpec extends IntegrationBaseSpec {
   val apiDefinitionJson: JsValue = Json.parse(
     """
       |{
-      |  "scopes": [
-      |    {
-      |      "key": "read:time-to-pay-proxy",
-      |      "name": "Time to pay proxy",
-      |      "description": "Allow read access to time to pay proxy"
-      |    }
-      |  ],
       |  "api": {
       |    "name": "Time To Pay Proxy",
       |    "description": "A API for Time To Pay Proxy.",

--- a/resources/public/api/definition.json
+++ b/resources/public/api/definition.json
@@ -1,11 +1,4 @@
 {
-  "scopes": [
-    {
-      "key": "read:time-to-pay-proxy",
-      "name": "Time to pay proxy",
-      "description": "Allow read access to time to pay proxy"
-    }
-  ],
   "api": {
     "name": "Time To Pay Proxy",
     "description": "A API for Time To Pay Proxy.",


### PR DESCRIPTION
Publishing an API containing scopes in its definition is no longer supported after 1st October.

**Acceptance Tests**

1. All scopes from the API’s definition are removed, where the definition is returned from calling the GET /api/definition endpoint on an API.
2. Scopes in the OAS (yaml) files are remained the same, as this is where they are used.