### PR TITLE
DTD-3098: Remove whitelistedApplicationIds from API definition as depracted

### DIFF
--- a/it/test/uk/gov/hmrc/timetopayproxy/config/DocumentationSpec.scala
+++ b/it/test/uk/gov/hmrc/timetopayproxy/config/DocumentationSpec.scala
@@ -34,8 +34,7 @@ class DocumentationControllerSpec extends IntegrationBaseSpec {
       |      {
       |        "version": "1.0",
       |        "access": {
-      |          "type": "PRIVATE",
-      |          "whitelistedApplicationIds": []
+      |          "type": "PRIVATE"
       |        },
       |        "status": "BETA",
       |        "endpointsEnabled": true

--- a/resources/public/api/definition.json
+++ b/resources/public/api/definition.json
@@ -7,8 +7,7 @@
       {
         "version": "1.0",
         "access": {
-          "type": "PRIVATE",
-          "whitelistedApplicationIds": []
+          "type": "PRIVATE"
         },
         "status": "BETA",
         "endpointsEnabled": true


### PR DESCRIPTION
This PR aims to remove `whitelistedApplicationIds` from API definition.