### PR TITLE
NOJIRA: Add ability to check dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,4 @@ tmp
 .idea_modules
 bin
 
-!/project/project/plugins-2.sbt
+!/project/project/*.sbt

--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,7 @@ modules
 /out
 precompiled
 /.project
-project/project
+project/project/*
 project/target
 /RUNNING_PID
 server.pid
@@ -33,3 +33,5 @@ test-result
 tmp
 .idea_modules
 bin
+
+!/project/project/plugins-2.sbt

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,5 +9,8 @@ addSbtPlugin("org.playframework" % "sbt-plugin"         % "3.0.6")
 addSbtPlugin("org.scoverage"     % "sbt-scoverage"      % "2.2.2")
 addSbtPlugin("org.scalameta"     % "sbt-scalafmt"       % "2.5.4")
 
+// To use this plugin, run: sbt dependencyUpdates
+addSbtPlugin("com.timushev.sbt"  % "sbt-updates"        % "0.6.4")
+
 /* Allows commands like `sbt dependencyBrowseGraph` to view the dependency graph locally. */
 addDependencyTreePlugin

--- a/project/project/plugins-2.sbt
+++ b/project/project/plugins-2.sbt
@@ -1,0 +1,2 @@
+// To use this plugin, run: (cd project && sbt dependencyUpdates)
+addSbtPlugin("com.timushev.sbt"  % "sbt-updates"        % "0.6.4")


### PR DESCRIPTION
Here are the outputs of the main build:
```
sbt dependencyUpdates

[info] Found 7 dependency updates for time-to-pay-proxy
[info]   com.fasterxml.jackson.module:jackson-module-scala:test : 2.18.2  -> 2.18.3           
[info]   com.networknt:json-schema-validator:test               : 1.5.5   -> 1.5.6            
[info]   org.playframework:play-test:test                       : 3.0.6   -> 3.0.7            
[info]   org.scala-lang:scala-library                           : 2.13.12 -> 2.13.16          
[info]   org.scalamock:scalamock:test                           : 5.2.0              -> 7.3.0 
[info]   uk.gov.hmrc:bootstrap-backend-play-30                  : 8.6.0              -> 9.11.0
[info]   uk.gov.hmrc:bootstrap-test-play-30:test                : 8.6.0              -> 9.11.0
```

And here are the outputs of the meta-build:
```
(cd project && sbt dependencyUpdates)

[info] Found 5 dependency updates for project
[info]   org.playframework:sbt-plugin      : 3.0.6   -> 3.0.7             
[info]   org.scala-lang:scala-library      : 2.12.19 -> 2.12.20 -> 2.13.16
[info]   org.scala-sbt:sbt-dependency-tree : 1.10.1  -> 1.10.11           
[info]   org.scoverage:sbt-scoverage       : 2.2.2              -> 2.3.1  
[info]   uk.gov.hmrc:sbt-distributables    : 2.5.0              -> 2.6.0  

```
