### PR TITLE
DTD-2344: add optional regime type to affordable quotes api request

### DIFF
--- a/app/uk/gov/hmrc/timetopayproxy/models/affordablequotes/AffordableQuotesRequest.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/models/affordablequotes/AffordableQuotesRequest.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.timetopayproxy.models.affordablequotes
 
 import play.api.libs.json.{ Json, OFormat }
-import uk.gov.hmrc.timetopayproxy.models.{ CustomerPostCode, DebtItemChargeSelfServe, Duration, FrequencyCapitalised }
+import uk.gov.hmrc.timetopayproxy.models.{ CustomerPostCode, DebtItemChargeSelfServe, Duration, FrequencyCapitalised, RegimeType }
 
 import java.time.LocalDate
 
@@ -32,7 +32,8 @@ final case class AffordableQuotesRequest(
   initialPaymentDate: Option[LocalDate],
   initialPaymentAmount: Option[BigInt],
   debtItemCharges: List[DebtItemChargeSelfServe],
-  customerPostcodes: List[CustomerPostCode]
+  customerPostcodes: List[CustomerPostCode],
+  regimeType: Option[RegimeType]
 )
 
 object AffordableQuotesRequest {

--- a/it/test/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyControllerItSpec.scala
+++ b/it/test/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyControllerItSpec.scala
@@ -315,7 +315,8 @@ class TimeToPayProxyControllerItSpec extends IntegrationBaseSpec {
           useChargeReference = UseChargeReference(false)
         )
       ),
-      customerPostcodes = List()
+      customerPostcodes = List(),
+      regimeType = Some(RegimeType.SA)
     )
   }
 }

--- a/it/test/uk/gov/hmrc/timetopayproxy/support/YamlSchemaValidatorSpec.scala
+++ b/it/test/uk/gov/hmrc/timetopayproxy/support/YamlSchemaValidatorSpec.scala
@@ -72,7 +72,8 @@ class YamlSchemaValidatorSpec extends AnyWordSpec with Matchers {
             useChargeReference = UseChargeReference(false)
           )
         ),
-        customerPostcodes = List(CustomerPostCode(PostCode("BN127ER"), postcodeDate = LocalDate.parse("2022-05-22")))
+        customerPostcodes = List(CustomerPostCode(PostCode("BN127ER"), postcodeDate = LocalDate.parse("2022-05-22"))),
+        regimeType = None
       )
 
     val affordableQuotesRequestWithAllFields: AffordableQuotesRequest =
@@ -85,7 +86,8 @@ class YamlSchemaValidatorSpec extends AnyWordSpec with Matchers {
             isInterestBearingCharge = IsInterestBearingCharge(true),
             useChargeReference = UseChargeReference(false)
           )
-        )
+        ),
+        regimeType = Some(RegimeType.SA)
       )
 
     def jsonBodyContainingOnlyMandatoryFields: JsValue =
@@ -124,7 +126,8 @@ class YamlSchemaValidatorSpec extends AnyWordSpec with Matchers {
                    |    {
                    |      "interestStartDate": "2022-05-22"
                    |    }
-                   |  ]
+                   |  ],
+                   |  "regimeType": "SA"
                    |  }""".stripMargin)
 
     def jsonBodyContainingABrokenField: JsValue =

--- a/resources/public/api/conf/1.0/application.yaml
+++ b/resources/public/api/conf/1.0/application.yaml
@@ -40,9 +40,9 @@ info:
       | 1.0.6 | 14-05-2025 | Alex Olkhovskiy | Added expectedPayment field to installments schema and response examples |
       | 1.0.7 | 14-05-2025 | Alex Olkhovskiy | Added channelIdentifier field to schemas to support Self Assessment debts |
       | 1.0.8 | 14-05-2025 | Alex Olkhovskiy | Added regimeType and dueDate fields to support Self Assessment debts |
-      | 1.0.8-proposedE | 14-05-2025 | Alex Olkhovskiy | Add regimeType to /affordable-quotes endpoint |
+      | 1.0.9 | 14-05-2025 | Alex Olkhovskiy | Add regimeType to /affordable-quotes endpoint |
   contact: {}
-  version: '1.0.8-proposedE'
+  version: '1.0.9'
 servers:
   - url: https://api.service.hmrc.gov.uk/
     variables: {}

--- a/resources/public/api/conf/1.0/application.yaml
+++ b/resources/public/api/conf/1.0/application.yaml
@@ -40,8 +40,9 @@ info:
       | 1.0.6 | 14-05-2025 | Alex Olkhovskiy | Added expectedPayment field to installments schema and response examples |
       | 1.0.7 | 14-05-2025 | Alex Olkhovskiy | Added channelIdentifier field to schemas to support Self Assessment debts |
       | 1.0.8 | 14-05-2025 | Alex Olkhovskiy | Added regimeType and dueDate fields to support Self Assessment debts |
+      | 1.0.8-proposedE | 14-05-2025 | Alex Olkhovskiy | Add regimeType to /affordable-quotes endpoint |
   contact: {}
-  version: '1.0.8'
+  version: '1.0.8-proposedE'
 servers:
   - url: https://api.service.hmrc.gov.uk/
     variables: {}
@@ -500,6 +501,7 @@ paths:
             schema:
               $ref: '#/components/schemas/AffordableQuotesRequest'
             example:
+              regimeType: PAYE
               channelIdentifier: advisor
               paymentPlanAffordableAmount: 1310
               paymentPlanFrequency: Monthly
@@ -693,6 +695,9 @@ components:
         - debtItemCharges
         - customerPostcodes
       properties:
+        regimeType:
+          type: string
+          description: Regime type
         channelIdentifier:
           type: string
         paymentPlanAffordableAmount:

--- a/test/uk/gov/hmrc/timetopayproxy/connectors/TtpConnectorSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/connectors/TtpConnectorSpec.scala
@@ -416,7 +416,8 @@ class TtpConnectorSpec extends PlaySpec with DefaultAwaitTimeout with FutureAwai
           useChargeReference = UseChargeReference(false)
         )
       ),
-      customerPostcodes = List()
+      customerPostcodes = List(),
+      regimeType = Some(RegimeType.SA)
     )
 
     val affordableQuoteResponse: AffordableQuoteResponse =

--- a/test/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyControllerSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyControllerSpec.scala
@@ -914,7 +914,8 @@ class TimeToPayProxyControllerSpec extends AnyWordSpec with Matchers with MockFa
           PostCode("some postcode"),
           LocalDate.parse("2022-03-09")
         )
-      )
+      ),
+      regimeType = Some(RegimeType.SA)
     )
     val affordableQuoteResponse = AffordableQuoteResponse(
       LocalDateTime.parse("2025-01-13T10:15:30.975"),

--- a/test/uk/gov/hmrc/timetopayproxy/services/TTPQuoteServiceSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/services/TTPQuoteServiceSpec.scala
@@ -244,7 +244,8 @@ class TTPQuoteServiceSpec extends UnitSpec {
         useChargeReference = UseChargeReference(false)
       )
     ),
-    customerPostcodes = List()
+    customerPostcodes = List(),
+    regimeType = Some(RegimeType.SA)
   )
 
   private val affordableQuoteResponse: AffordableQuoteResponse =


### PR DESCRIPTION
Small update as part of of this story: [DTD-2344](https://jira.tools.tax.service.gov.uk/browse/DTD-2344)

- added optional `regimeType` to Affordable Quotes API request