### PR TITLE
DTD-3520: Update Generate Quote API Request to use OpLedRegimeType

### DIFF
--- a/app/uk/gov/hmrc/timetopayproxy/models/GenerateQuoteRequest.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/models/GenerateQuoteRequest.scala
@@ -60,7 +60,7 @@ final case class GenerateQuoteRequest(
   plan: PlanToGenerateQuote,
   customerPostCodes: List[CustomerPostCode],
   debtItemCharges: List[QuoteDebtItemCharge],
-  regimeType: Option[SsttpRegimeType]
+  regimeType: Option[OpLedRegimeType]
 ) {
   require(!customerReference.value.trim().isEmpty(), "customerReference should not be empty")
 }

--- a/test/uk/gov/hmrc/timetopayproxy/models/GenerateQuoteRequestSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/models/GenerateQuoteRequestSpec.scala
@@ -49,7 +49,7 @@ class GenerateQuoteRequestSpec extends AnyWordSpec with Matchers {
         dueDate = Some(LocalDate.of(2021, 5, 13))
       )
     ),
-    regimeType = Some(SsttpRegimeType.SA)
+    regimeType = Some(OpLedRegimeType.SA)
   )
 
   val json = """{


### PR DESCRIPTION
Very tiny change to `GenerateQuoteRequest` - just updates the `regimeType` to be `OpLedRegimeType` instead of `SsttpRegimeType`

Part of [DTD-3520](https://jira.tools.tax.service.gov.uk/browse/DTD-3520)

TTP [PR](https://github.com/hmrc/time-to-pay/pull/437)