### PR TITLE
DTD-3634/DTD-3687: Refactoring: Remove unnecessary error JSON formats.

### DIFF
--- a/app/uk/gov/hmrc/timetopayproxy/models/TimeToPayEligibilityError.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/models/TimeToPayEligibilityError.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.timetopayproxy.models
 
-import play.api.libs.json.{ Json, OFormat }
+import play.api.libs.json.{ Json, Reads }
 
 case class TimeToPayEligibilityError(code: String, reason: String) extends IncomingApiError {
   def toConnectorError(status: Int): ConnectorError =
@@ -24,5 +24,5 @@ case class TimeToPayEligibilityError(code: String, reason: String) extends Incom
 }
 
 object TimeToPayEligibilityError {
-  implicit val format: OFormat[TimeToPayEligibilityError] = Json.format[TimeToPayEligibilityError]
+  implicit val reader: Reads[TimeToPayEligibilityError] = Json.reads[TimeToPayEligibilityError]
 }

--- a/app/uk/gov/hmrc/timetopayproxy/models/TimeToPayError.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/models/TimeToPayError.scala
@@ -16,9 +16,13 @@
 
 package uk.gov.hmrc.timetopayproxy.models
 
-import play.api.libs.json.{ Json, OFormat }
+import play.api.libs.json.{ Json, Reads }
 
 final case class TimeToPayInnerError(code: String, reason: String)
+
+object TimeToPayInnerError {
+  implicit val reader: Reads[TimeToPayInnerError] = Json.reads[TimeToPayInnerError]
+}
 
 final case class TimeToPayError(failures: Seq[TimeToPayInnerError]) extends IncomingApiError {
   def toConnectorError(status: Int): ConnectorError =
@@ -28,10 +32,6 @@ final case class TimeToPayError(failures: Seq[TimeToPayInnerError]) extends Inco
     )
 }
 
-object TimeToPayInnerError {
-  implicit val format: OFormat[TimeToPayInnerError] = Json.format[TimeToPayInnerError]
-}
-
 object TimeToPayError {
-  implicit val format: OFormat[TimeToPayError] = Json.format[TimeToPayError]
+  implicit val reader: Reads[TimeToPayError] = Json.reads[TimeToPayError]
 }

--- a/app/uk/gov/hmrc/timetopayproxy/models/TtppErrorResponse.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/models/TtppErrorResponse.scala
@@ -16,10 +16,10 @@
 
 package uk.gov.hmrc.timetopayproxy.models
 
-import play.api.libs.json.{ Json, OFormat }
+import play.api.libs.json.{ Json, Writes }
 
 final case class TtppErrorResponse(statusCode: Int, errorMessage: String)
 
 object TtppErrorResponse {
-  implicit val format: OFormat[TtppErrorResponse] = Json.format[TtppErrorResponse]
+  implicit val writer: Writes[TtppErrorResponse] = Json.writes[TtppErrorResponse]
 }

--- a/app/uk/gov/hmrc/timetopayproxy/utils/TtppResponseConverter.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/utils/TtppResponseConverter.scala
@@ -16,14 +16,14 @@
 
 package uk.gov.hmrc.timetopayproxy.utils
 
-import play.api.libs.json.{ Format, Json }
+import play.api.libs.json.{ Json, Writes }
 import play.api.mvc.{ Result, Results }
 import uk.gov.hmrc.timetopayproxy.models.TtppErrorResponse
 
 object TtppResponseConverter {
 
   implicit class ToResponse[T](response: T) {
-    def toResponse(implicit format: Format[T]): Result =
+    def toResponse(implicit writer: Writes[T]): Result =
       response match {
         case TtppErrorResponse(statusCode, _) =>
           Results.Status(statusCode)(Json.toJson(response))

--- a/it/test/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyControllerItSpec.scala
+++ b/it/test/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyControllerItSpec.scala
@@ -23,6 +23,7 @@ import uk.gov.hmrc.timetopayproxy.models._
 import uk.gov.hmrc.timetopayproxy.models.affordablequotes.{ AffordableQuoteResponse, AffordableQuotesRequest }
 import uk.gov.hmrc.timetopayproxy.models.chargeInfoApi._
 import uk.gov.hmrc.timetopayproxy.support.IntegrationBaseSpec
+import uk.gov.hmrc.timetopayproxy.testutils.TestOnlyJsonFormats._
 
 import java.time.{ LocalDate, LocalDateTime }
 import scala.concurrent.ExecutionContext

--- a/it/test/uk/gov/hmrc/timetopayproxy/testutils/TestOnlyJsonFormats.scala
+++ b/it/test/uk/gov/hmrc/timetopayproxy/testutils/TestOnlyJsonFormats.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.timetopayproxy.testutils
+
+import play.api.libs.json.{ Json, Writes }
+import uk.gov.hmrc.timetopayproxy.models.{ TimeToPayEligibilityError, TimeToPayError, TimeToPayInnerError }
+
+/** Provider of JSON writers and readers that have no use in production.
+  * Kept here instead of in the main code so we can avoid the ambiguity that would arise from having unused formats.
+  */
+object TestOnlyJsonFormats {
+  // Ensure these aren't full formats so they don't clash with the production writers/readers.
+
+  implicit val testOnlyWritesTimeToPayError: Writes[TimeToPayError] = {
+    implicit val testOnlyWritesTimeToPayInnerError: Writes[TimeToPayInnerError] =
+      Json.writes[TimeToPayInnerError]
+
+    Json.writes[TimeToPayError]
+  }
+
+  implicit val testOnlyWritesTimeToPayEligibilityError: Writes[TimeToPayEligibilityError] =
+    Json.writes[TimeToPayEligibilityError]
+
+}


### PR DESCRIPTION
Keeping (and testing) these useless JSON readers and writers would be impossible to explain in the tests, because the JSON format tests added as part of #133 also contained references to the data flow that the formats were used for.

The plan to remove these was why the new tests in #133 didn't check some of the writers/readers. I was planning to remove them. But this didn't belong in _that_ PR because it was meant to be test-only.