### PR TITLE
DTD-2858: Refactoring: Move & rename Identification/IDType/IDValue to make them consistent.

### DIFF
--- a/app/uk/gov/hmrc/timetopayproxy/models/IdType.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/models/IdType.scala
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.timetopayproxy.models.chargeInfoApi
+package uk.gov.hmrc.timetopayproxy.models
 
 import play.api.libs.json.{ Format, Json }
 
-case class Identification(idType: IDType, idValue: IDValue)
+final case class IdType(value: String) extends AnyVal
 
-object Identification {
-  implicit val format: Format[Identification] = Json.format[Identification]
+object IdType {
+  implicit val format: Format[IdType] = Json.valueFormat[IdType]
 }

--- a/app/uk/gov/hmrc/timetopayproxy/models/IdValue.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/models/IdValue.scala
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.timetopayproxy.models.chargeInfoApi
+package uk.gov.hmrc.timetopayproxy.models
 
 import play.api.libs.json.{ Format, Json }
 
-final case class IDType(value: String) extends AnyVal
+final case class IdValue(value: String) extends AnyVal
 
-object IDType {
-  implicit val format: Format[IDType] = Json.valueFormat[IDType]
+object IdValue {
+  implicit val format: Format[IdValue] = Json.valueFormat[IdValue]
 }

--- a/app/uk/gov/hmrc/timetopayproxy/models/Identification.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/models/Identification.scala
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.timetopayproxy.models.chargeInfoApi
+package uk.gov.hmrc.timetopayproxy.models
 
 import play.api.libs.json.{ Format, Json }
 
-final case class IDValue(value: String) extends AnyVal
+case class Identification(idType: IdType, idValue: IdValue)
 
-object IDValue {
-  implicit val format: Format[IDValue] = Json.valueFormat[IDValue]
+object Identification {
+  implicit val format: Format[Identification] = Json.format[Identification]
 }

--- a/app/uk/gov/hmrc/timetopayproxy/models/chargeInfoApi/ChargeInfoRequest.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/models/chargeInfoApi/ChargeInfoRequest.scala
@@ -19,6 +19,7 @@ package uk.gov.hmrc.timetopayproxy.models.chargeInfoApi
 import cats.data.NonEmptyList
 import enumeratum.{ Enum, EnumEntry, PlayJsonEnum }
 import play.api.libs.json.{ Format, Json, OFormat }
+import uk.gov.hmrc.timetopayproxy.models.Identification
 import uk.gov.hmrc.timetopayproxy.utils.json.CatsNonEmptyListJson
 
 import scala.collection.immutable

--- a/app/uk/gov/hmrc/timetopayproxy/models/chargeInfoApi/ChargeInfoResponse.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/models/chargeInfoApi/ChargeInfoResponse.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.timetopayproxy.models.chargeInfoApi
 
 import enumeratum.{ Enum, EnumEntry, PlayJsonEnum }
 import play.api.libs.json.{ Format, Json, OFormat }
+import uk.gov.hmrc.timetopayproxy.models.Identification
 
 import java.time.{ LocalDate, LocalDateTime }
 import scala.collection.immutable

--- a/it/test/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyControllerItSpec.scala
+++ b/it/test/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyControllerItSpec.scala
@@ -630,7 +630,7 @@ class TimeToPayProxyControllerItSpec extends IntegrationBaseSpec {
     val ttpeResponse: ChargeInfoResponse = ChargeInfoResponse(
       processingDateTime = LocalDateTime.parse("2025-07-02T15:00:41.689"),
       identification = List(
-        Identification(idType = IDType("ID_TYPE"), idValue = IDValue("ID_VALUE"))
+        Identification(idType = IdType("ID_TYPE"), idValue = IdValue("ID_VALUE"))
       ),
       individualDetails = IndividualDetails(
         title = Some(Title("Mr")),
@@ -699,8 +699,8 @@ class TimeToPayProxyControllerItSpec extends IntegrationBaseSpec {
     val chargeInfoRequest: ChargeInfoRequest = ChargeInfoRequest(
       channelIdentifier = ChargeInfoChannelIdentifier("Channel Identifier"),
       identifications = NonEmptyList.of(
-        Identification(idType = IDType("id type 1"), idValue = IDValue("id value 1")),
-        Identification(idType = IDType("id type 2"), idValue = IDValue("id value 2"))
+        Identification(idType = IdType("id type 1"), idValue = IdValue("id value 1")),
+        Identification(idType = IdType("id type 2"), idValue = IdValue("id value 2"))
       ),
       regimeType = RegimeType.SA
     )

--- a/test/uk/gov/hmrc/timetopayproxy/connectors/TtpeConnectorSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/connectors/TtpeConnectorSpec.scala
@@ -26,7 +26,7 @@ import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 import uk.gov.hmrc.timetopayproxy.config.AppConfig
-import uk.gov.hmrc.timetopayproxy.models.ConnectorError
+import uk.gov.hmrc.timetopayproxy.models.{ ConnectorError, IdType, IdValue, Identification }
 import uk.gov.hmrc.timetopayproxy.models.TtppEnvelope.TtppEnvelope
 import uk.gov.hmrc.timetopayproxy.models.chargeInfoApi._
 import uk.gov.hmrc.timetopayproxy.support.WireMockUtils
@@ -95,8 +95,8 @@ class TtpeConnectorSpec
     def chargeInfoRequest: ChargeInfoRequest = ChargeInfoRequest(
       channelIdentifier = ChargeInfoChannelIdentifier("Channel Identifier"),
       identifications = NonEmptyList.of(
-        Identification(idType = IDType("id type 1"), idValue = IDValue("id value 1")),
-        Identification(idType = IDType("id type 2"), idValue = IDValue("id value 2"))
+        Identification(idType = IdType("id type 1"), idValue = IdValue("id value 1")),
+        Identification(idType = IdType("id type 2"), idValue = IdValue("id value 2"))
       ),
       regimeType = RegimeType.SA
     )
@@ -104,7 +104,7 @@ class TtpeConnectorSpec
     def chargeInfoResponse: ChargeInfoResponse = ChargeInfoResponse(
       processingDateTime = LocalDateTime.parse("2025-07-02T15:00:41.689"),
       identification = List(
-        Identification(idType = IDType("ID_TYPE"), idValue = IDValue("ID_VALUE"))
+        Identification(idType = IdType("ID_TYPE"), idValue = IdValue("ID_VALUE"))
       ),
       individualDetails = IndividualDetails(
         title = Some(Title("Mr")),

--- a/test/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyControllerSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyControllerSpec.scala
@@ -1028,15 +1028,15 @@ class TimeToPayProxyControllerSpec extends AnyWordSpec with MockFactory {
     val chargeInfoRequest: ChargeInfoRequest = ChargeInfoRequest(
       channelIdentifier = ChargeInfoChannelIdentifier("Channel Identifier"),
       identifications = NonEmptyList.of(
-        Identification(idType = IDType("id type 1"), idValue = IDValue("id value 1")),
-        Identification(idType = IDType("id type 2"), idValue = IDValue("id value 2"))
+        Identification(idType = IdType("id type 1"), idValue = IdValue("id value 1")),
+        Identification(idType = IdType("id type 2"), idValue = IdValue("id value 2"))
       ),
       regimeType = RegimeType.SA
     )
     val chargeInfoResponse: ChargeInfoResponse = ChargeInfoResponse(
       processingDateTime = LocalDateTime.parse("2025-07-02T15:00:41.689"),
       identification = List(
-        Identification(idType = IDType("ID_TYPE"), idValue = IDValue("ID_VALUE"))
+        Identification(idType = IdType("ID_TYPE"), idValue = IdValue("ID_VALUE"))
       ),
       individualDetails = IndividualDetails(
         title = Some(Title("Mr")),

--- a/test/uk/gov/hmrc/timetopayproxy/models/chargeInfoApi/ChargeInfoRequestSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/models/chargeInfoApi/ChargeInfoRequestSpec.scala
@@ -20,6 +20,7 @@ import cats.data.NonEmptyList
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers._
 import play.api.libs.json.{ JsSuccess, JsValue, Json, Reads, Writes }
+import uk.gov.hmrc.timetopayproxy.models.{ IdType, IdValue, Identification }
 import uk.gov.hmrc.timetopayproxy.testutils.JsonAssertionOps._
 import uk.gov.hmrc.timetopayproxy.testutils.schematestutils.Validators
 
@@ -30,8 +31,8 @@ class ChargeInfoRequestSpec extends AnyFreeSpec {
       def obj: ChargeInfoRequest = ChargeInfoRequest(
         channelIdentifier = ChargeInfoChannelIdentifier("Channel Identifier"),
         identifications = NonEmptyList.of(
-          Identification(idType = IDType("id type 1"), idValue = IDValue("id value 1")),
-          Identification(idType = IDType("id type 2"), idValue = IDValue("id value 2"))
+          Identification(idType = IdType("id type 1"), idValue = IdValue("id value 1")),
+          Identification(idType = IdType("id type 2"), idValue = IdValue("id value 2"))
         ),
         regimeType = RegimeType.SA
       )

--- a/test/uk/gov/hmrc/timetopayproxy/models/chargeInfoApi/ChargeInfoResponseSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/models/chargeInfoApi/ChargeInfoResponseSpec.scala
@@ -19,6 +19,7 @@ package uk.gov.hmrc.timetopayproxy.models.chargeInfoApi
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers._
 import play.api.libs.json.{ JsSuccess, JsValue, Json, Reads, Writes }
+import uk.gov.hmrc.timetopayproxy.models.{ IdType, IdValue, Identification }
 import uk.gov.hmrc.timetopayproxy.testutils.JsonAssertionOps.RichJsValueWithAssertions
 import uk.gov.hmrc.timetopayproxy.testutils.schematestutils.Validators
 
@@ -31,7 +32,7 @@ class ChargeInfoResponseSpec extends AnyFreeSpec {
       def obj: ChargeInfoResponse = ChargeInfoResponse(
         processingDateTime = LocalDateTime.parse("2025-07-02T15:00:41.689"),
         identification = List(
-          Identification(idType = IDType("ID_TYPE"), idValue = IDValue("ID_VALUE"))
+          Identification(idType = IdType("ID_TYPE"), idValue = IdValue("ID_VALUE"))
         ),
         individualDetails = IndividualDetails(
           title = Some(Title("Mr")),
@@ -181,7 +182,7 @@ class ChargeInfoResponseSpec extends AnyFreeSpec {
       def obj: ChargeInfoResponse = ChargeInfoResponse(
         processingDateTime = LocalDateTime.parse("2025-07-02T15:00:41.689"),
         identification = List(
-          Identification(idType = IDType("ID_TYPE"), idValue = IDValue("ID_VALUE"))
+          Identification(idType = IdType("ID_TYPE"), idValue = IdValue("ID_VALUE"))
         ),
         individualDetails = IndividualDetails(
           title = None,
@@ -320,7 +321,7 @@ class ChargeInfoResponseSpec extends AnyFreeSpec {
       def obj: ChargeInfoResponse = ChargeInfoResponse(
         processingDateTime = LocalDateTime.parse("2025-07-02T15:00:41.689"),
         identification = List(
-          Identification(idType = IDType("ID_TYPE"), idValue = IDValue("ID_VALUE"))
+          Identification(idType = IdType("ID_TYPE"), idValue = IdValue("ID_VALUE"))
         ),
         individualDetails = IndividualDetails(
           title = None,

--- a/test/uk/gov/hmrc/timetopayproxy/services/TTPEServiceSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/services/TTPEServiceSpec.scala
@@ -26,7 +26,7 @@ import uk.gov.hmrc.http.HeaderCarrier
 import scala.concurrent.ExecutionContext.Implicits.global
 import uk.gov.hmrc.timetopayproxy.connectors.TtpeConnector
 import uk.gov.hmrc.timetopayproxy.models.TtppEnvelope.TtppEnvelope
-import uk.gov.hmrc.timetopayproxy.models.{ ConnectorError, TtppEnvelope, TtppError }
+import uk.gov.hmrc.timetopayproxy.models.{ ConnectorError, IdType, IdValue, Identification, TtppEnvelope, TtppError }
 import uk.gov.hmrc.timetopayproxy.models.chargeInfoApi._
 
 import java.time.{ LocalDate, LocalDateTime }
@@ -38,8 +38,8 @@ class TTPEServiceSpec extends AnyFreeSpec {
   private val chargeInfoRequest: ChargeInfoRequest = ChargeInfoRequest(
     channelIdentifier = ChargeInfoChannelIdentifier("Channel Identifier"),
     identifications = NonEmptyList.of(
-      Identification(idType = IDType("id type 1"), idValue = IDValue("id value 1")),
-      Identification(idType = IDType("id type 2"), idValue = IDValue("id value 2"))
+      Identification(idType = IdType("id type 1"), idValue = IdValue("id value 1")),
+      Identification(idType = IdType("id type 2"), idValue = IdValue("id value 2"))
     ),
     regimeType = RegimeType.SA
   )
@@ -47,7 +47,7 @@ class TTPEServiceSpec extends AnyFreeSpec {
   private val chargeInfoResponse: ChargeInfoResponse = ChargeInfoResponse(
     processingDateTime = LocalDateTime.parse("2025-07-02T15:00:41.689"),
     identification = List(
-      Identification(idType = IDType("ID_TYPE"), idValue = IDValue("ID_VALUE"))
+      Identification(idType = IdType("ID_TYPE"), idValue = IdValue("ID_VALUE"))
     ),
     individualDetails = IndividualDetails(
       title = Some(Title("Mr")),


### PR DESCRIPTION
- The naming of `IDType` and `IDValue` was not consistent with any of our classes.
- The naming of `IDType` and `IDValue` was inconsistent with `time-to-pay`.
- Their location wasn't correct because we will need to use them in a new TTP endpoint.
