### PR TITLE
DTD-2858: Refactoring: Optimise all imports in IntelliJ.

### DIFF
--- a/app/uk/gov/hmrc/timetopayproxy/actions/auth/AuthoriseAction.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/actions/auth/AuthoriseAction.scala
@@ -17,14 +17,14 @@
 package uk.gov.hmrc.timetopayproxy.actions.auth
 
 import com.google.inject.ImplementedBy
-import javax.inject.Inject
 import play.api.Logger
+import play.api.mvc.Results.{ Forbidden, ServiceUnavailable }
 import play.api.mvc._
 import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.http.HeaderCarrierConverter
-import play.api.mvc.Results.{ Forbidden, ServiceUnavailable }
 
+import javax.inject.Inject
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.control.NonFatal
 

--- a/app/uk/gov/hmrc/timetopayproxy/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/config/AppConfig.scala
@@ -16,9 +16,10 @@
 
 package uk.gov.hmrc.timetopayproxy.config
 
-import javax.inject.{ Inject, Singleton }
 import play.api.Configuration
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
+
+import javax.inject.{ Inject, Singleton }
 
 @Singleton
 class AppConfig @Inject() (

--- a/app/uk/gov/hmrc/timetopayproxy/config/DocumentationController.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/config/DocumentationController.scala
@@ -16,15 +16,15 @@
 
 package uk.gov.hmrc.timetopayproxy.config
 
-import javax.inject.{ Inject, Singleton }
 import controllers.Assets
 import org.apache.pekko.stream.Materializer
 import play.api.Configuration
 import play.api.mvc.{ Action, AnyContent, ControllerComponents }
 import play.filters.cors.CORSActionBuilder
-
-import scala.concurrent.ExecutionContext
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
+
+import javax.inject.{ Inject, Singleton }
+import scala.concurrent.ExecutionContext
 
 @Singleton
 class DocumentationController @Inject() (

--- a/app/uk/gov/hmrc/timetopayproxy/connectors/HttpParser.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/connectors/HttpParser.scala
@@ -16,11 +16,11 @@
 
 package uk.gov.hmrc.timetopayproxy.connectors
 
+import cats.syntax.either._
 import play.api.http.Status
 import play.api.libs.json.Reads
 import uk.gov.hmrc.http.HttpReads
 import uk.gov.hmrc.timetopayproxy.models.{ ConnectorError, IncomingApiError, TtppError }
-import cats.syntax.either._
 
 import scala.util.{ Failure, Success, Try }
 

--- a/app/uk/gov/hmrc/timetopayproxy/connectors/TtpTestConnector.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/connectors/TtpTestConnector.scala
@@ -20,12 +20,12 @@ import cats.implicits.catsSyntaxEitherId
 import com.google.inject.ImplementedBy
 import play.api.http.Status.{ NO_CONTENT, OK }
 import play.api.libs.json.Json
+import uk.gov.hmrc.http.HttpReads.Implicits._
+import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.http.{ HeaderCarrier, HttpException, HttpResponse, StringContextOps, UpstreamErrorResponse }
 import uk.gov.hmrc.timetopayproxy.config.AppConfig
 import uk.gov.hmrc.timetopayproxy.models.TtppEnvelope.TtppEnvelope
 import uk.gov.hmrc.timetopayproxy.models.{ ConnectorError, RequestDetails, TtppEnvelope }
-import uk.gov.hmrc.http.HttpReads.Implicits._
-import uk.gov.hmrc.http.client.HttpClientV2
 
 import javax.inject.{ Inject, Singleton }
 import scala.concurrent.ExecutionContext

--- a/app/uk/gov/hmrc/timetopayproxy/connectors/TtpeConnector.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/connectors/TtpeConnector.scala
@@ -19,12 +19,12 @@ package uk.gov.hmrc.timetopayproxy.connectors
 import cats.data.EitherT
 import com.google.inject.ImplementedBy
 import play.api.libs.json.Json
-import uk.gov.hmrc.http.{ HeaderCarrier, StringContextOps }
 import uk.gov.hmrc.http.client.HttpClientV2
+import uk.gov.hmrc.http.{ HeaderCarrier, StringContextOps }
 import uk.gov.hmrc.timetopayproxy.config.AppConfig
 import uk.gov.hmrc.timetopayproxy.models.TtppEnvelope.TtppEnvelope
-import uk.gov.hmrc.timetopayproxy.models.{ TimeToPayEligibilityError, TtppError }
 import uk.gov.hmrc.timetopayproxy.models.chargeInfoApi.{ ChargeInfoRequest, ChargeInfoResponse }
+import uk.gov.hmrc.timetopayproxy.models.{ TimeToPayEligibilityError, TtppError }
 
 import java.util.UUID
 import javax.inject.{ Inject, Singleton }

--- a/app/uk/gov/hmrc/timetopayproxy/models/BreathingSpace.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/models/BreathingSpace.scala
@@ -15,8 +15,9 @@
  */
 
 package uk.gov.hmrc.timetopayproxy.models
-import java.time.LocalDate
 import play.api.libs.json.{ Json, OFormat }
+
+import java.time.LocalDate
 
 case class BreathingSpace(debtRespiteFrom: LocalDate, debtRespiteTo: LocalDate)
 

--- a/app/uk/gov/hmrc/timetopayproxy/models/CustomerPostCode.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/models/CustomerPostCode.scala
@@ -15,8 +15,9 @@
  */
 
 package uk.gov.hmrc.timetopayproxy.models
-import java.time.LocalDate
 import play.api.libs.json.{ Format, Json, OFormat }
+
+import java.time.LocalDate
 
 final case class PostCode(value: String) extends AnyVal
 

--- a/app/uk/gov/hmrc/timetopayproxy/models/DebtItemCharge.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/models/DebtItemCharge.scala
@@ -16,8 +16,9 @@
 
 package uk.gov.hmrc.timetopayproxy.models
 
-import java.time.LocalDate
 import play.api.libs.json.{ Format, Json, OFormat }
+
+import java.time.LocalDate
 
 final case class DebtItemChargeId(value: String) extends AnyVal
 

--- a/app/uk/gov/hmrc/timetopayproxy/models/GenerateQuoteRequest.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/models/GenerateQuoteRequest.scala
@@ -32,8 +32,9 @@ package uk.gov.hmrc.timetopayproxy.models
  * limitations under the License.
  */
 
-import java.time.LocalDate
 import play.api.libs.json.{ Json, OFormat }
+
+import java.time.LocalDate
 
 final case class PlanToGenerateQuote(
   quoteType: QuoteType,

--- a/app/uk/gov/hmrc/timetopayproxy/models/GenerateQuoteResponse.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/models/GenerateQuoteResponse.scala
@@ -16,8 +16,9 @@
 
 package uk.gov.hmrc.timetopayproxy.models
 
-import java.time.LocalDate
 import play.api.libs.json.{ Json, OFormat }
+
+import java.time.LocalDate
 
 final case class GenerateQuoteResponse(
   quoteReference: QuoteReference,

--- a/app/uk/gov/hmrc/timetopayproxy/models/UpdatePlanRequest.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/models/UpdatePlanRequest.scala
@@ -16,8 +16,8 @@
 
 package uk.gov.hmrc.timetopayproxy.models
 
-import play.api.libs.json.{ Format, Json, OFormat }
 import enumeratum.{ Enum, EnumEntry, PlayJsonEnum }
+import play.api.libs.json.{ Format, Json, OFormat }
 
 import scala.collection.immutable
 

--- a/app/uk/gov/hmrc/timetopayproxy/models/UpdatePlanResponse.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/models/UpdatePlanResponse.scala
@@ -16,8 +16,9 @@
 
 package uk.gov.hmrc.timetopayproxy.models
 
-import java.time.LocalDate
 import play.api.libs.json.{ Json, OFormat }
+
+import java.time.LocalDate
 
 final case class UpdatePlanResponse(
   customerReference: CustomerReference,

--- a/app/uk/gov/hmrc/timetopayproxy/services/TTPQuoteService.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/services/TTPQuoteService.scala
@@ -17,14 +17,13 @@
 package uk.gov.hmrc.timetopayproxy.services
 
 import com.google.inject.ImplementedBy
-
-import javax.inject.{ Inject, Singleton }
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.timetopayproxy.connectors.TtpConnector
-import uk.gov.hmrc.timetopayproxy.models._
 import uk.gov.hmrc.timetopayproxy.models.TtppEnvelope.TtppEnvelope
+import uk.gov.hmrc.timetopayproxy.models._
 import uk.gov.hmrc.timetopayproxy.models.affordablequotes.{ AffordableQuoteResponse, AffordableQuotesRequest }
 
+import javax.inject.{ Inject, Singleton }
 import scala.concurrent.ExecutionContext
 
 @ImplementedBy(classOf[DefaultTTPQuoteService])

--- a/test/uk/gov/hmrc/timetopayproxy/connectors/TtpeConnectorSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/connectors/TtpeConnectorSpec.scala
@@ -26,9 +26,9 @@ import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 import uk.gov.hmrc.timetopayproxy.config.AppConfig
-import uk.gov.hmrc.timetopayproxy.models.{ ConnectorError, IdType, IdValue, Identification }
 import uk.gov.hmrc.timetopayproxy.models.TtppEnvelope.TtppEnvelope
 import uk.gov.hmrc.timetopayproxy.models.chargeInfoApi._
+import uk.gov.hmrc.timetopayproxy.models.{ ConnectorError, IdType, IdValue, Identification }
 import uk.gov.hmrc.timetopayproxy.support.WireMockUtils
 
 import java.time.{ LocalDate, LocalDateTime }

--- a/test/uk/gov/hmrc/timetopayproxy/models/CreatePlanRequestSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/models/CreatePlanRequestSpec.scala
@@ -16,12 +16,11 @@
 
 package uk.gov.hmrc.timetopayproxy.models
 
-import java.time.LocalDate
-
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import play.api.libs.json._
 
+import java.time.LocalDate
 import scala.util.{ Failure, Try }
 
 class CreatePlanRequestSpec extends AnyWordSpec with Matchers with CreatePlanRequestFixture {

--- a/test/uk/gov/hmrc/timetopayproxy/models/GenerateQuoteRequestSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/models/GenerateQuoteRequestSpec.scala
@@ -15,11 +15,11 @@
  */
 
 package uk.gov.hmrc.timetopayproxy.models
-import java.time.LocalDate
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import play.api.libs.json._
 
+import java.time.LocalDate
 import scala.util.{ Failure, Try }
 
 class GenerateQuoteRequestSpec extends AnyWordSpec with Matchers {

--- a/test/uk/gov/hmrc/timetopayproxy/models/GenerateQuoteResponseSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/models/GenerateQuoteResponseSpec.scala
@@ -16,11 +16,11 @@
 
 package uk.gov.hmrc.timetopayproxy.models
 
-import java.time.LocalDate
-
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import play.api.libs.json._
+
+import java.time.LocalDate
 
 class GenerateQuoteResponseSpec extends AnyWordSpec with Matchers {
   val generateQuoteResponse = GenerateQuoteResponse(

--- a/test/uk/gov/hmrc/timetopayproxy/services/TTPEServiceSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/services/TTPEServiceSpec.scala
@@ -22,14 +22,13 @@ import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers._
 import play.api.test.Helpers.{ await, defaultAwaitTimeout }
 import uk.gov.hmrc.http.HeaderCarrier
-
-import scala.concurrent.ExecutionContext.Implicits.global
 import uk.gov.hmrc.timetopayproxy.connectors.TtpeConnector
 import uk.gov.hmrc.timetopayproxy.models.TtppEnvelope.TtppEnvelope
-import uk.gov.hmrc.timetopayproxy.models.{ ConnectorError, IdType, IdValue, Identification, TtppEnvelope, TtppError }
 import uk.gov.hmrc.timetopayproxy.models.chargeInfoApi._
+import uk.gov.hmrc.timetopayproxy.models.{ ConnectorError, IdType, IdValue, Identification, TtppEnvelope, TtppError }
 
 import java.time.{ LocalDate, LocalDateTime }
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ ExecutionContext, Future }
 
 class TTPEServiceSpec extends AnyFreeSpec {

--- a/test/uk/gov/hmrc/timetopayproxy/services/TTPQuoteServiceSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/services/TTPQuoteServiceSpec.scala
@@ -16,18 +16,18 @@
 
 package uk.gov.hmrc.timetopayproxy.services
 
-import java.time.{ LocalDate, LocalDateTime }
-import java.util.concurrent.TimeUnit
+import cats.syntax.either._
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.timetopayproxy.connectors.TtpConnector
+import uk.gov.hmrc.timetopayproxy.models.TtppEnvelope.TtppEnvelope
 import uk.gov.hmrc.timetopayproxy.models._
+import uk.gov.hmrc.timetopayproxy.models.affordablequotes.{ AffordableQuoteResponse, AffordableQuotesRequest }
 import uk.gov.hmrc.timetopayproxy.support.UnitSpec
 
-import scala.concurrent.{ ExecutionContext, Future }
+import java.time.{ LocalDate, LocalDateTime }
+import java.util.concurrent.TimeUnit
 import scala.concurrent.ExecutionContext.Implicits.global
-import cats.syntax.either._
-import uk.gov.hmrc.timetopayproxy.models.TtppEnvelope.TtppEnvelope
-import uk.gov.hmrc.timetopayproxy.models.affordablequotes.{ AffordableQuoteResponse, AffordableQuotesRequest }
+import scala.concurrent.{ ExecutionContext, Future }
 
 class TTPQuoteServiceSpec extends UnitSpec {
   implicit val hc: HeaderCarrier = HeaderCarrier()

--- a/test/uk/gov/hmrc/timetopayproxy/services/TTPTestServiceSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/services/TTPTestServiceSpec.scala
@@ -16,14 +16,15 @@
 
 package uk.gov.hmrc.timetopayproxy.services
 
+import cats.syntax.either._
+import play.api.libs.json.Json
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.timetopayproxy.connectors.TtpTestConnector
 import uk.gov.hmrc.timetopayproxy.models.{ ConnectorError, RequestDetails, TtppEnvelope, TtppError }
 import uk.gov.hmrc.timetopayproxy.support.UnitSpec
-import scala.concurrent.ExecutionContext.Implicits.global
-import cats.syntax.either._
-import play.api.libs.json.Json
+
 import scala.concurrent.ExecutionContext
+import scala.concurrent.ExecutionContext.Implicits.global
 
 class TTPTestServiceSpec extends UnitSpec {
   implicit val hc: HeaderCarrier = HeaderCarrier()

--- a/test/uk/gov/hmrc/timetopayproxy/services/UpdateQuoteServiceSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/services/UpdateQuoteServiceSpec.scala
@@ -16,15 +16,14 @@
 
 package uk.gov.hmrc.timetopayproxy.services
 
-import java.time.LocalDate
-import java.util.concurrent.TimeUnit
-
 import cats.syntax.either._
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.timetopayproxy.connectors.TtpConnector
 import uk.gov.hmrc.timetopayproxy.models._
 import uk.gov.hmrc.timetopayproxy.support.UnitSpec
 
+import java.time.LocalDate
+import java.util.concurrent.TimeUnit
 import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContext.Implicits.global
 


### PR DESCRIPTION
They were being annoying on my main implementation branch, so I decided to just get them all done at once. (It can be done by selecting a package and hitting `CTRL+OPTION+O`) This is the grouping we've used in other repos, and I believe this is also the IntelliJ default.

Scalafmt won't deal with this kind of stuff.