### PR TITLE
DTD-3975: Fix the CorrelationId issues in time-to-pay-proxy (Dev Only)

### DIFF
--- a/app/uk/gov/hmrc/timetopayproxy/actions/correlationid/CorrelationIdPopulationAction.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/actions/correlationid/CorrelationIdPopulationAction.scala
@@ -25,7 +25,8 @@ import java.util.UUID
 import javax.inject.Inject
 import scala.concurrent.{ ExecutionContext, Future }
 
-class CorrelationIdPopulationAction @Inject() ()(implicit ec: ExecutionContext) extends ActionTransformer[Request, Request] {
+class CorrelationIdPopulationAction @Inject() ()(implicit ec: ExecutionContext)
+    extends ActionTransformer[Request, Request] {
   private val logger = new RequestAwareLogger(this.getClass)
 
   override protected def transform[A](request: Request[A]): Future[Request[A]] = {
@@ -34,10 +35,14 @@ class CorrelationIdPopulationAction @Inject() ()(implicit ec: ExecutionContext) 
     request.headers.get("correlationId") match {
       case Some(correlationId) =>
         // The .remove then .add will handle case insensitivity and keep it consistent when propagating
-        Future.successful(request.withHeaders(request.headers.remove("correlationId").add("correlationId" -> correlationId)))
+        Future.successful(
+          request.withHeaders(request.headers.remove("correlationId").add("correlationId" -> correlationId))
+        )
       case None =>
         val generatedCorrelationId = UUID.randomUUID().toString
-        logger.warn(s"[CORRELATION ID] Not found in request header for ${request.uri}, generated new correlationId: $generatedCorrelationId")(
+        logger.warn(
+          s"[CORRELATION ID] Not found in request header for ${request.uri}, generated new correlationId: $generatedCorrelationId"
+        )(
           baseHeaderCarrier
         )
         Future.successful(request.withHeaders(request.headers.add("correlationId" -> generatedCorrelationId)))

--- a/app/uk/gov/hmrc/timetopayproxy/actions/correlationid/CorrelationIdPopulationAction.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/actions/correlationid/CorrelationIdPopulationAction.scala
@@ -32,11 +32,12 @@ class CorrelationIdPopulationAction @Inject() ()(implicit ec: ExecutionContext) 
     val baseHeaderCarrier: HeaderCarrier = HeaderCarrierConverter.fromRequest(request)
 
     request.headers.get("correlationId") match {
-      case Some(_) =>
-        Future.successful(request)
+      case Some(correlationId) =>
+        // The .remove then .add will handle case insensitivity and keep it consistent when propagating
+        Future.successful(request.withHeaders(request.headers.remove("correlationId").add("correlationId" -> correlationId)))
       case None =>
         val generatedCorrelationId = UUID.randomUUID().toString
-        logger.warn(s"No correlationId found in request header for ${request.uri}, generated: $generatedCorrelationId")(
+        logger.warn(s"[CORRELATION ID] Not found in request header for ${request.uri}, generated new correlationId: $generatedCorrelationId")(
           baseHeaderCarrier
         )
         Future.successful(request.withHeaders(request.headers.add("correlationId" -> generatedCorrelationId)))

--- a/app/uk/gov/hmrc/timetopayproxy/actions/correlationid/CorrelationIdPopulationAction.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/actions/correlationid/CorrelationIdPopulationAction.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.timetopayproxy.actions.correlationid
+
+import play.api.mvc.{ ActionTransformer, Request }
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.http.HeaderCarrierConverter
+import uk.gov.hmrc.timetopayproxy.logging.RequestAwareLogger
+
+import java.util.UUID
+import javax.inject.Inject
+import scala.concurrent.{ ExecutionContext, Future }
+
+class CorrelationIdPopulationAction @Inject() ()(implicit ec: ExecutionContext) extends ActionTransformer[Request, Request] {
+  private val logger = new RequestAwareLogger(this.getClass)
+
+  override protected def transform[A](request: Request[A]): Future[Request[A]] = {
+    val baseHeaderCarrier: HeaderCarrier = HeaderCarrierConverter.fromRequest(request)
+
+    request.headers.get("correlationId") match {
+      case Some(_) =>
+        Future.successful(request)
+      case None =>
+        val generatedCorrelationId = UUID.randomUUID().toString
+        logger.warn(s"No correlationId found in request header for ${request.uri}, generated: $generatedCorrelationId")(
+          baseHeaderCarrier
+        )
+        Future.successful(request.withHeaders(request.headers.add("correlationId" -> generatedCorrelationId)))
+    }
+  }
+
+  override protected def executionContext: ExecutionContext = ec
+}

--- a/app/uk/gov/hmrc/timetopayproxy/connectors/TtpConnector.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/connectors/TtpConnector.scala
@@ -20,9 +20,9 @@ import cats.data.EitherT
 import com.google.inject.ImplementedBy
 import play.api.libs.json.Json
 import uk.gov.hmrc.http.client.HttpClientV2
-import uk.gov.hmrc.timetopayproxy.connectors.util.httpreadsbuilder.HttpReadsBuilder
 import uk.gov.hmrc.http.{ HeaderCarrier, HttpReads, StringContextOps }
 import uk.gov.hmrc.timetopayproxy.config.{ AppConfig, FeatureSwitch }
+import uk.gov.hmrc.timetopayproxy.connectors.util.httpreadsbuilder.HttpReadsBuilder
 import uk.gov.hmrc.timetopayproxy.logging.RequestAwareLogger
 import uk.gov.hmrc.timetopayproxy.models._
 import uk.gov.hmrc.timetopayproxy.models.affordablequotes.{ AffordableQuoteResponse, AffordableQuotesRequest }
@@ -30,7 +30,6 @@ import uk.gov.hmrc.timetopayproxy.models.error.ProxyEnvelopeError
 import uk.gov.hmrc.timetopayproxy.models.error.TtppEnvelope.TtppEnvelope
 
 import java.net.URLEncoder
-import java.util.UUID
 import javax.inject.{ Inject, Singleton }
 import scala.concurrent.ExecutionContext
 
@@ -99,11 +98,6 @@ class DefaultTtpConnector @Inject() (appConfig: AppConfig, httpClient: HttpClien
 
   val headers: String => Seq[(String, String)] = (guid: String) => Seq("CorrelationId" -> s"$guid")
 
-  private def getOrGenerateCorrelationId(implicit hc: HeaderCarrier): String =
-    (hc.headers(Seq("CorrelationId")) ++ hc.extraHeaders)
-      .toMap[String, String]
-      .getOrElse("CorrelationId", UUID.randomUUID().toString)
-
   def generateQuote(
     ttppRequest: GenerateQuoteRequest,
     queryParams: Seq[(String, String)] = Seq.empty
@@ -122,7 +116,7 @@ class DefaultTtpConnector @Inject() (appConfig: AppConfig, httpClient: HttpClien
       httpClient
         .post(url)
         .withBody(Json.toJson(ttppRequest))
-        .setHeader(headers(getOrGenerateCorrelationId): _*)
+        .setHeader(combinedHeaders: _*)
         .execute[Either[ProxyEnvelopeError, GenerateQuoteResponse]]
     )
   }
@@ -194,8 +188,7 @@ class DefaultTtpConnector @Inject() (appConfig: AppConfig, httpClient: HttpClien
         Seq.empty
       }
 
-    val headers: Seq[(String, String)] =
-      Seq("CorrelationId" -> getOrGenerateCorrelationId) ++ authorizationHeader
+    val headers: Seq[(String, String)] = combinedHeaders ++ authorizationHeader
 
     EitherT(
       httpClient
@@ -229,4 +222,7 @@ class DefaultTtpConnector @Inject() (appConfig: AppConfig, httpClient: HttpClien
     val paramPairs = queryParams.map { case (k, v) => s"$k=${URLEncoder.encode(v, "utf-8")}" }
     if (paramPairs.isEmpty) "" else paramPairs.mkString("?", "&", "")
   }
+
+  private def combinedHeaders(implicit hc: HeaderCarrier): Seq[(String, String)] =
+    hc.headers(List("correlationId")) ++ hc.extraHeaders
 }

--- a/app/uk/gov/hmrc/timetopayproxy/connectors/TtpConnector.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/connectors/TtpConnector.scala
@@ -136,6 +136,7 @@ class DefaultTtpConnector @Inject() (appConfig: AppConfig, httpClient: HttpClien
     EitherT(
       httpClient
         .get(url)
+        .setHeader(combinedHeaders: _*)
         .execute[Either[ProxyEnvelopeError, ViewPlanResponse]]
     )
   }

--- a/app/uk/gov/hmrc/timetopayproxy/connectors/TtpConnector.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/connectors/TtpConnector.scala
@@ -216,6 +216,7 @@ class DefaultTtpConnector @Inject() (appConfig: AppConfig, httpClient: HttpClien
       httpClient
         .post(url)
         .withBody(Json.toJson(affordableQuotesRequest))
+        .setHeader(combinedHeaders: _*)
         .execute[Either[ProxyEnvelopeError, AffordableQuoteResponse]]
     )
   }

--- a/app/uk/gov/hmrc/timetopayproxy/connectors/TtpConnector.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/connectors/TtpConnector.scala
@@ -163,6 +163,7 @@ class DefaultTtpConnector @Inject() (appConfig: AppConfig, httpClient: HttpClien
       httpClient
         .put(url)
         .withBody(Json.toJson(updatePlanRequest))
+        .setHeader(combinedHeaders: _*)
         .execute[Either[ProxyEnvelopeError, UpdatePlanResponse]]
     )
   }

--- a/app/uk/gov/hmrc/timetopayproxy/connectors/TtpFeedbackLoopConnector.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/connectors/TtpFeedbackLoopConnector.scala
@@ -30,7 +30,6 @@ import uk.gov.hmrc.timetopayproxy.models.saonly.ttpcancel.{ TtpCancelInformative
 import uk.gov.hmrc.timetopayproxy.models.saonly.ttpfullamend.{ FullAmendRequest, TtpFullAmendInformativeError, TtpFullAmendSuccessfulResponse }
 import uk.gov.hmrc.timetopayproxy.models.saonly.ttpinform.{ TtpInformInformativeError, TtpInformRequest, TtpInformSuccessfulResponse }
 
-import java.util.UUID
 import javax.inject.{ Inject, Singleton }
 import scala.concurrent.ExecutionContext
 
@@ -153,23 +152,13 @@ class TtpFeedbackLoopConnector @Inject() (
   }
 
   private def requestHeaders(implicit hc: HeaderCarrier): Seq[(String, String)] = {
-    val correlationId: String = getOrGenerateCorrelationId
+    val combinedPreviousHeaders: Seq[(String, String)] = hc.headers(List("correlationId")) ++ hc.extraHeaders
 
     if (featureSwitch.internalAuthEnabled.enabled) {
-      Seq(
-        "Authorization" -> appConfig.internalAuthToken,
-        "CorrelationId" -> correlationId
-      )
+      ("Authorization" -> appConfig.internalAuthToken) +: combinedPreviousHeaders
     } else {
-      Seq(
-        "CorrelationId" -> correlationId
-      )
+      combinedPreviousHeaders
     }
   }
-
-  private def getOrGenerateCorrelationId(implicit hc: HeaderCarrier): String =
-    (hc.headers(Seq("CorrelationId")) ++ hc.extraHeaders)
-      .toMap[String, String]
-      .getOrElse("CorrelationId", UUID.randomUUID().toString)
 
 }

--- a/app/uk/gov/hmrc/timetopayproxy/connectors/TtpeConnector.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/connectors/TtpeConnector.scala
@@ -29,7 +29,6 @@ import uk.gov.hmrc.timetopayproxy.models.error.ProxyEnvelopeError
 import uk.gov.hmrc.timetopayproxy.models.error.TtppEnvelope.TtppEnvelope
 import uk.gov.hmrc.timetopayproxy.models.saonly.chargeInfoApi.{ ChargeInfoRequest, ChargeInfoResponse, ChargeInfoResponseR1, ChargeInfoResponseR2 }
 
-import java.util.UUID
 import javax.inject.{ Inject, Singleton }
 import scala.concurrent.ExecutionContext
 
@@ -44,7 +43,7 @@ trait TtpeConnector {
 class DefaultTtpeConnector @Inject() (appConfig: AppConfig, httpClient: HttpClientV2, featureSwitch: FeatureSwitch)
     extends TtpeConnector {
 
-  private val logger: RequestAwareLogger = new RequestAwareLogger(classOf[DefaultTtpConnector])
+  private val logger: RequestAwareLogger = new RequestAwareLogger(classOf[DefaultTtpeConnector])
 
   private val httpReadsBuilderForChargeInfoR1: HttpReadsBuilder[ProxyEnvelopeError, ChargeInfoResponse] =
     HttpReadsBuilder
@@ -68,11 +67,6 @@ class DefaultTtpeConnector @Inject() (appConfig: AppConfig, httpClient: HttpClie
   val headers: String => Seq[(String, String)] = (guid: String) =>
     Seq("CorrelationId" -> s"$guid") ++ authorizationHeader
 
-  private def getOrGenerateCorrelationId(implicit hc: HeaderCarrier): String =
-    (hc.headers(Seq("CorrelationId")) ++ hc.extraHeaders)
-      .toMap[String, String]
-      .getOrElse("CorrelationId", UUID.randomUUID().toString)
-
   def checkChargeInfo(chargeInfoRequest: ChargeInfoRequest)(implicit
     ec: ExecutionContext,
     hc: HeaderCarrier
@@ -91,8 +85,11 @@ class DefaultTtpeConnector @Inject() (appConfig: AppConfig, httpClient: HttpClie
       httpClient
         .post(url)
         .withBody(Json.toJson(chargeInfoRequest))
-        .setHeader(headers(getOrGenerateCorrelationId): _*)
+        .setHeader(combinedHeaders: _*)
         .execute[Either[ProxyEnvelopeError, ChargeInfoResponse]]
     )
   }
+
+  private def combinedHeaders(implicit hc: HeaderCarrier): Seq[(String, String)] =
+    hc.headers(List("correlationId")) ++ hc.extraHeaders
 }

--- a/app/uk/gov/hmrc/timetopayproxy/connectors/TtpeConnector.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/connectors/TtpeConnector.scala
@@ -59,14 +59,6 @@ class DefaultTtpeConnector @Inject() (appConfig: AppConfig, httpClient: HttpClie
       .handleErrorTransformed[TimeToPayEligibilityError](400, ttpeError => ttpeError.toConnectorError(status = 400))
       .handleErrorTransformed[TimeToPayEligibilityError](422, ttpeError => ttpeError.toConnectorError(status = 422))
 
-  private val authorizationHeader: Seq[(String, String)] =
-    if (featureSwitch.internalAuthEnabled.enabled)
-      Seq("Authorization" -> appConfig.internalAuthToken)
-    else Seq.empty
-
-  val headers: String => Seq[(String, String)] = (guid: String) =>
-    Seq("CorrelationId" -> s"$guid") ++ authorizationHeader
-
   def checkChargeInfo(chargeInfoRequest: ChargeInfoRequest)(implicit
     ec: ExecutionContext,
     hc: HeaderCarrier
@@ -85,11 +77,18 @@ class DefaultTtpeConnector @Inject() (appConfig: AppConfig, httpClient: HttpClie
       httpClient
         .post(url)
         .withBody(Json.toJson(chargeInfoRequest))
-        .setHeader(combinedHeaders: _*)
+        .setHeader(requestHeaders: _*)
         .execute[Either[ProxyEnvelopeError, ChargeInfoResponse]]
     )
   }
 
-  private def combinedHeaders(implicit hc: HeaderCarrier): Seq[(String, String)] =
-    hc.headers(List("correlationId")) ++ hc.extraHeaders
+  private def requestHeaders(implicit hc: HeaderCarrier): Seq[(String, String)] = {
+    val combinedPreviousHeaders: Seq[(String, String)] = hc.headers(List("correlationId")) ++ hc.extraHeaders
+
+    if (featureSwitch.internalAuthEnabled.enabled) {
+      ("Authorization" -> appConfig.internalAuthToken) +: combinedPreviousHeaders
+    } else {
+      combinedPreviousHeaders
+    }
+  }
 }

--- a/app/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyController.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyController.scala
@@ -122,7 +122,7 @@ class TimeToPayProxyController @Inject() (
     }
   }
 
-  def cancelTtp: Action[JsValue] = readAuthoriseAction.async(parse.json) { implicit request =>
+  def cancelTtp: Action[JsValue] = authThenCorrelationIdActions.async(parse.json) { implicit request =>
     if (featureSwitch.cancelEndpointEnabled) {
       if (featureSwitch.saRelease2Enabled.enabled) {
         withJsonBody[TtpCancelRequestR2] { deserialisedRequest: TtpCancelRequestR2 =>

--- a/app/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyController.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyController.scala
@@ -64,7 +64,7 @@ class TimeToPayProxyController @Inject() (
   }
 
   def viewPlan(customerReference: String, planId: String) =
-    readAuthoriseAction.async { implicit request =>
+    authThenCorrelationIdActions.async { implicit request =>
       timeToPayQuoteService
         .getExistingPlan(CustomerReference(customerReference), PlanId(planId))
         .leftMap(ttppError => ttppError.toWriteableProxyError)

--- a/app/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyController.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyController.scala
@@ -146,7 +146,7 @@ class TimeToPayProxyController @Inject() (
     }
   }
 
-  def informTtp: Action[JsValue] = readAuthoriseAction.async(parse.json) { implicit request =>
+  def informTtp: Action[JsValue] = authThenCorrelationIdActions.async(parse.json) { implicit request =>
     if (featureSwitch.informEndpointEnabled) {
       withJsonBody[TtpInformRequest] { deserialisedRequest: TtpInformRequest =>
         ttpFeedbackLoopService

--- a/app/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyController.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyController.scala
@@ -21,6 +21,7 @@ import play.api.libs.json._
 import play.api.mvc._
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 import uk.gov.hmrc.timetopayproxy.actions.auth.ReadAuthoriseAction
+import uk.gov.hmrc.timetopayproxy.actions.correlationid.CorrelationIdPopulationAction
 import uk.gov.hmrc.timetopayproxy.config.FeatureSwitch
 import uk.gov.hmrc.timetopayproxy.models._
 import uk.gov.hmrc.timetopayproxy.models.affordablequotes.AffordableQuotesRequest
@@ -38,6 +39,7 @@ import scala.util.{ Failure, Success, Try }
 
 @Singleton()
 class TimeToPayProxyController @Inject() (
+  correlationIdPopulationAction: CorrelationIdPopulationAction,
   readAuthoriseAction: ReadAuthoriseAction,
   cc: ControllerComponents,
   timeToPayQuoteService: TTPQuoteService,
@@ -50,7 +52,9 @@ class TimeToPayProxyController @Inject() (
   private val queryParameterNotMatchingPayload =
     "customerReference and planId in the query parameters should match the ones in the request payload"
 
-  def generateQuote: Action[JsValue] = readAuthoriseAction.async(parse.json) { implicit request =>
+  private val authThenCorrelationIdActions = readAuthoriseAction andThen correlationIdPopulationAction
+
+  def generateQuote: Action[JsValue] = authThenCorrelationIdActions.async(parse.json) { implicit request =>
     withJsonBody[GenerateQuoteRequest] { timeToPayRequest: GenerateQuoteRequest =>
       timeToPayQuoteService
         .generateQuote(timeToPayRequest, request.queryString)

--- a/app/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyController.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyController.scala
@@ -86,7 +86,7 @@ class TimeToPayProxyController @Inject() (
       }
     }
 
-  def createPlan = readAuthoriseAction.async(parse.json) { implicit request =>
+  def createPlan = authThenCorrelationIdActions.async(parse.json) { implicit request =>
     withJsonBody[CreatePlanRequest] { createPlanRequest: CreatePlanRequest =>
       timeToPayQuoteService
         .createPlan(createPlanRequest, request.queryString)

--- a/app/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyController.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyController.scala
@@ -104,7 +104,7 @@ class TimeToPayProxyController @Inject() (
     }
   }
 
-  def checkChargeInfo: Action[JsValue] = readAuthoriseAction.async(parse.json) { implicit request =>
+  def checkChargeInfo: Action[JsValue] = authThenCorrelationIdActions.async(parse.json) { implicit request =>
     if (featureSwitch.chargeInfoEndpointEnabled) {
       withJsonBody[ChargeInfoRequest] { chargeInfoRequest: ChargeInfoRequest =>
         timeToPayEligibilityService

--- a/app/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyController.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyController.scala
@@ -95,7 +95,7 @@ class TimeToPayProxyController @Inject() (
     }
   }
 
-  def getAffordableQuotes = readAuthoriseAction.async(parse.json) { implicit request =>
+  def getAffordableQuotes = authThenCorrelationIdActions.async(parse.json) { implicit request =>
     withJsonBody[AffordableQuotesRequest] { affordableQuoteRequest: AffordableQuotesRequest =>
       timeToPayQuoteService
         .getAffordableQuotes(affordableQuoteRequest)

--- a/app/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyController.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyController.scala
@@ -161,7 +161,7 @@ class TimeToPayProxyController @Inject() (
     }
   }
 
-  def fullAmendTtp: Action[JsValue] = readAuthoriseAction.async(parse.json) { implicit request =>
+  def fullAmendTtp: Action[JsValue] = authThenCorrelationIdActions.async(parse.json) { implicit request =>
     if (featureSwitch.fullAmendEndpointEnabled) {
       implicit val requestFormat: OFormat[FullAmendRequest] = FullAmendRequest.format(featureSwitch)
       withJsonBody[FullAmendRequest] { deserialisedRequest: FullAmendRequest =>

--- a/app/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyController.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyController.scala
@@ -72,7 +72,7 @@ class TimeToPayProxyController @Inject() (
     }
 
   def updatePlan(customerReference: String, planId: String): Action[JsValue] =
-    readAuthoriseAction.async(parse.json) { implicit request =>
+    authThenCorrelationIdActions.async(parse.json) { implicit request =>
       withJsonBody[UpdatePlanRequest] { updatePlanRequest: UpdatePlanRequest =>
         val result = for {
           validatedUpdatePlanRequest <-

--- a/it/test/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyControllerCorrelationIdItSpec.scala
+++ b/it/test/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyControllerCorrelationIdItSpec.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.timetopayproxy.controllers
 
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock._
-import com.github.tomakehurst.wiremock.http.RequestMethod.POST
+import com.github.tomakehurst.wiremock.http.RequestMethod.{GET,POST}
 import play.api.libs.json.Json
 import play.api.libs.ws.WSRequest
 import uk.gov.hmrc.timetopayproxy.models._
@@ -96,6 +96,62 @@ class TimeToPayProxyControllerCorrelationIdItSpec extends IntegrationBaseSpec {
           .withHeader("correlationId", matching(uuidRegex))
           .withHeader("correlationId", WireMock.not(equalTo(testCorrelationId)))
       )
+    }
+  }
+
+  ".viewPlan" - {
+    val customerReference = "testCustomerReference"
+    val planId = "testPlanId"
+
+    "should propagate a correlationId to TTP when it's provided one in the request" in {
+      stubRequest(
+        httpMethod = GET,
+        url = s"/debts/time-to-pay/quote/$customerReference/$planId",
+        status = 200,
+        responseBody = ""
+      )
+
+      val request: WSRequest =
+        buildRequest(s"/quote/$customerReference/$planId")
+          .withHttpHeaders("correlationId" -> testCorrelationId)
+
+      await(request.get())
+
+      verify(
+        getRequestedFor(urlEqualTo(s"/debts/time-to-pay/quote/$customerReference/$planId"))
+          .withHeader("correlationId", equalTo(testCorrelationId))
+      )
+    }
+
+    "should generate a new correlationId to send to TTP when it's not provided in the request" in {
+      stubRequest(
+        httpMethod = GET,
+        url = s"/debts/time-to-pay/quote/$customerReference/$planId",
+        status = 200,
+        responseBody = ""
+      )
+
+      val request: WSRequest = buildRequest(s"/quote/$customerReference/$planId")
+
+      request.header("correlationId") shouldBe None
+
+      await(request.get())
+
+      verify(
+        getRequestedFor(urlEqualTo(s"/debts/time-to-pay/quote/$customerReference/$planId"))
+          .withHeader("correlationId", matching(uuidRegex))
+          .withHeader("correlationId", WireMock.not(equalTo(testCorrelationId)))
+      )
+    }
+  }
+
+  ".AAAAAAA" - {
+    "should propagate a correlationId to TTP when it's provided one in the request" in {
+
+    }
+
+    "should generate a new correlationId to send to TTP when it's not provided in the request" in {
+
     }
   }
 }

--- a/it/test/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyControllerCorrelationIdItSpec.scala
+++ b/it/test/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyControllerCorrelationIdItSpec.scala
@@ -19,16 +19,16 @@ package uk.gov.hmrc.timetopayproxy.controllers
 import cats.data.NonEmptyList
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock._
-import com.github.tomakehurst.wiremock.http.RequestMethod.{GET, POST, PUT}
+import com.github.tomakehurst.wiremock.http.RequestMethod.{ GET, POST, PUT }
 import play.api.libs.json.Json
 import play.api.libs.ws.WSRequest
 import uk.gov.hmrc.timetopayproxy.models._
 import uk.gov.hmrc.timetopayproxy.models.affordablequotes.AffordableQuotesRequest
 import uk.gov.hmrc.timetopayproxy.models.currency.GbpPounds
-import uk.gov.hmrc.timetopayproxy.models.saonly.chargeInfoApi.{ChargeInfoChannelIdentifier, ChargeInfoRequest}
-import uk.gov.hmrc.timetopayproxy.models.saonly.common.{ArrangementAgreedDate, ChargeSourceSAOnly, DdiReference, DebtItemChargeReference, InitialPaymentDate, SaOnlyInstalment, SaOnlyPaymentPlan, SaOnlyRegimeType, TransitionedIndicator, TtpEndDate}
-import uk.gov.hmrc.timetopayproxy.models.saonly.ttpcancel.{CancellationDate, TtpCancelPaymentPlanR2, TtpCancelRequestR2}
-import uk.gov.hmrc.timetopayproxy.models.saonly.ttpfullamend.{ChargeAmendment, NewDebtItemChargeReference, NewPaymentPlan, OriginalPaymentPlan, TtpFullAmendRequestR2}
+import uk.gov.hmrc.timetopayproxy.models.saonly.chargeInfoApi.{ ChargeInfoChannelIdentifier, ChargeInfoRequest }
+import uk.gov.hmrc.timetopayproxy.models.saonly.common.{ ArrangementAgreedDate, ChargeSourceSAOnly, DdiReference, DebtItemChargeReference, InitialPaymentDate, SaOnlyInstalment, SaOnlyPaymentPlan, SaOnlyRegimeType, TransitionedIndicator, TtpEndDate }
+import uk.gov.hmrc.timetopayproxy.models.saonly.ttpcancel.{ CancellationDate, TtpCancelPaymentPlanR2, TtpCancelRequestR2 }
+import uk.gov.hmrc.timetopayproxy.models.saonly.ttpfullamend.{ ChargeAmendment, NewDebtItemChargeReference, NewPaymentPlan, OriginalPaymentPlan, TtpFullAmendRequestR2 }
 import uk.gov.hmrc.timetopayproxy.models.saonly.ttpinform.TtpInformRequest
 import uk.gov.hmrc.timetopayproxy.support.IntegrationBaseSpec
 

--- a/it/test/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyControllerCorrelationIdItSpec.scala
+++ b/it/test/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyControllerCorrelationIdItSpec.scala
@@ -28,6 +28,7 @@ import uk.gov.hmrc.timetopayproxy.models.currency.GbpPounds
 import uk.gov.hmrc.timetopayproxy.models.saonly.chargeInfoApi.{ChargeInfoChannelIdentifier, ChargeInfoRequest}
 import uk.gov.hmrc.timetopayproxy.models.saonly.common.{ArrangementAgreedDate, ChargeSourceSAOnly, DdiReference, DebtItemChargeReference, InitialPaymentDate, SaOnlyInstalment, SaOnlyPaymentPlan, SaOnlyRegimeType, TransitionedIndicator, TtpEndDate}
 import uk.gov.hmrc.timetopayproxy.models.saonly.ttpcancel.{CancellationDate, TtpCancelPaymentPlanR2, TtpCancelRequestR2}
+import uk.gov.hmrc.timetopayproxy.models.saonly.ttpfullamend.{ChargeAmendment, NewDebtItemChargeReference, NewPaymentPlan, OriginalPaymentPlan, TtpFullAmendRequestR2}
 import uk.gov.hmrc.timetopayproxy.models.saonly.ttpinform.TtpInformRequest
 import uk.gov.hmrc.timetopayproxy.support.IntegrationBaseSpec
 
@@ -101,7 +102,6 @@ class TimeToPayProxyControllerCorrelationIdItSpec extends IntegrationBaseSpec {
       verify(
         postRequestedFor(urlEqualTo("/debts/time-to-pay/quote"))
           .withHeader("correlationId", matching(uuidRegex))
-          .withHeader("correlationId", WireMock.not(equalTo(testCorrelationId)))
       )
     }
   }
@@ -147,7 +147,6 @@ class TimeToPayProxyControllerCorrelationIdItSpec extends IntegrationBaseSpec {
       verify(
         getRequestedFor(urlEqualTo(s"/debts/time-to-pay/quote/$customerReference/$planId"))
           .withHeader("correlationId", matching(uuidRegex))
-          .withHeader("correlationId", WireMock.not(equalTo(testCorrelationId)))
       )
     }
   }
@@ -214,7 +213,6 @@ class TimeToPayProxyControllerCorrelationIdItSpec extends IntegrationBaseSpec {
       verify(
         putRequestedFor(urlEqualTo(s"/debts/time-to-pay/quote/$customerReference/$planId"))
           .withHeader("correlationId", matching(uuidRegex))
-          .withHeader("correlationId", WireMock.not(equalTo(testCorrelationId)))
       )
     }
   }
@@ -316,7 +314,6 @@ class TimeToPayProxyControllerCorrelationIdItSpec extends IntegrationBaseSpec {
       verify(
         postRequestedFor(urlEqualTo("/debts/time-to-pay/quote/arrangement"))
           .withHeader("correlationId", matching(uuidRegex))
-          .withHeader("correlationId", WireMock.not(equalTo(testCorrelationId)))
       )
     }
   }
@@ -394,7 +391,6 @@ class TimeToPayProxyControllerCorrelationIdItSpec extends IntegrationBaseSpec {
       verify(
         postRequestedFor(urlEqualTo("/debts/time-to-pay/affordability/affordable-quotes"))
           .withHeader("correlationId", matching(uuidRegex))
-          .withHeader("correlationId", WireMock.not(equalTo(testCorrelationId)))
       )
     }
   }
@@ -450,7 +446,6 @@ class TimeToPayProxyControllerCorrelationIdItSpec extends IntegrationBaseSpec {
       verify(
         postRequestedFor(urlEqualTo("/debts/time-to-pay/charge-info"))
           .withHeader("correlationId", matching(uuidRegex))
-          .withHeader("correlationId", WireMock.not(equalTo(testCorrelationId)))
       )
     }
   }
@@ -537,7 +532,6 @@ class TimeToPayProxyControllerCorrelationIdItSpec extends IntegrationBaseSpec {
       verify(
         postRequestedFor(urlEqualTo("/debts/time-to-pay/cancel"))
           .withHeader("correlationId", matching(uuidRegex))
-          .withHeader("correlationId", WireMock.not(equalTo(testCorrelationId)))
       )
     }
   }
@@ -614,18 +608,100 @@ class TimeToPayProxyControllerCorrelationIdItSpec extends IntegrationBaseSpec {
       verify(
         postRequestedFor(urlEqualTo("/debts/time-to-pay/inform"))
           .withHeader("correlationId", matching(uuidRegex))
-          .withHeader("correlationId", WireMock.not(equalTo(testCorrelationId)))
       )
     }
   }
 
-  ".AAAAAAA" - {
-    "should propagate a correlationId to TTP when it's provided one in the request" in {
+  ".fullAmendTtp" - {
+    val fullAmendRequest: TtpFullAmendRequestR2 =
+      TtpFullAmendRequestR2(
+        identifications = NonEmptyList.of(
+          Identification(
+            idType = IdType("idtype"),
+            idValue = IdValue("idvalue")
+          )
+        ),
+        originalPaymentPlan = OriginalPaymentPlan(
+          arrangementAgreedDate = ArrangementAgreedDate(LocalDate.parse("2020-01-02")),
+          ttpEndDate = TtpEndDate(LocalDate.parse("2020-02-04")),
+          frequency = FrequencyLowercase.Weekly,
+          initialPaymentDate = Some(InitialPaymentDate(LocalDate.parse("2020-04-06"))),
+          initialPaymentAmount = Some(GbpPounds.createOrThrow(100.12)),
+          ddiReference = Some(DdiReference("TestDDIReference")),
+          debtItemCharges = NonEmptyList.of(
+            DebtItemChargeReference(
+              DebtItemChargeId("One"),
+              ChargeSourceSAOnly.CESA
+            )
+          )
+        ),
+        newPaymentPlan = NewPaymentPlan(
+          arrangementAgreedDate = ArrangementAgreedDate(LocalDate.parse("2020-01-02")),
+          ttpEndDate = TtpEndDate(LocalDate.parse("2020-02-04")),
+          frequency = FrequencyLowercase.Weekly,
+          ddiReference = Some(DdiReference("TestDDIReference")),
+          initialPaymentDate = Some(InitialPaymentDate(LocalDate.parse("2020-04-06"))),
+          initialPaymentAmount = Some(GbpPounds.createOrThrow(100.12)),
+          debtItemCharges = NonEmptyList.of(
+            NewDebtItemChargeReference(
+              DebtItemChargeId("One"),
+              ChargeSourceSAOnly.CESA,
+              ChargeAmendment.Removed
+            )
+          )
+        ),
+        instalments = NonEmptyList.of(
+          SaOnlyInstalment(
+            dueDate = InstalmentDueDate(LocalDate.parse("2020-05-07")),
+            amountDue = GbpPounds.createOrThrow(200.34)
+          )
+        ),
+        channelIdentifier = ChannelIdentifier.SelfService,
+        transitioned = TransitionedIndicator(true)
+      )
 
+    "should propagate a correlationId to TTP when it's provided one in the request" in {
+      stubRequest(
+        httpMethod = POST,
+        url = "/debts/time-to-pay/full-amend",
+        status = 200,
+        responseBody = ""
+      )
+
+      val request: WSRequest =
+        buildRequest("/full-amend")
+          .withHttpHeaders("correlationId" -> testCorrelationId)
+
+      await(
+        request.post(Json.toJson(fullAmendRequest))
+      )
+
+      verify(
+        postRequestedFor(urlEqualTo("/debts/time-to-pay/full-amend"))
+          .withHeader("correlationId", equalTo(testCorrelationId))
+      )
     }
 
     "should generate a new correlationId to send to TTP when it's not provided in the request" in {
+      stubRequest(
+        httpMethod = POST,
+        url = "/debts/time-to-pay/full-amend",
+        status = 200,
+        responseBody = ""
+      )
 
+      val request: WSRequest = buildRequest("/full-amend")
+
+      request.header("correlationId") shouldBe None
+
+      await(
+        request.post(Json.toJson(fullAmendRequest))
+      )
+
+      verify(
+        postRequestedFor(urlEqualTo("/debts/time-to-pay/full-amend"))
+          .withHeader("correlationId", matching(uuidRegex))
+      )
     }
   }
 }

--- a/it/test/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyControllerCorrelationIdItSpec.scala
+++ b/it/test/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyControllerCorrelationIdItSpec.scala
@@ -212,6 +212,108 @@ class TimeToPayProxyControllerCorrelationIdItSpec extends IntegrationBaseSpec {
     }
   }
 
+  ".createPlan" - {
+    val createPlanRequest: CreatePlanRequest = CreatePlanRequest(
+      CustomerReference("customerReference"),
+      QuoteReference("quoteReference"),
+      ChannelIdentifier.Advisor,
+      PlanToCreatePlan(
+        QuoteId("quoteId"),
+        QuoteType.Duration,
+        quoteDate = LocalDate.parse("2010-02-02"),
+        instalmentStartDate = LocalDate.parse("2010-02-02"),
+        instalmentAmount = Some(100),
+        PaymentPlanType.TimeToPay,
+        thirdPartyBank = false,
+        numberOfInstalments = 2,
+        Some(FrequencyLowercase.Single),
+        Some(Duration(2)),
+        Some(PaymentMethod.Bacs),
+        Some(PaymentReference("ref123")),
+        initialPaymentDate = Some(LocalDate.parse("2010-02-02")),
+        initialPaymentAmount = Some(100),
+        totalDebtIncInt = 100,
+        totalInterest = 10,
+        interestAccrued = 10,
+        planInterest = 10
+      ),
+      List(
+        CreatePlanDebtItemCharge(
+          DebtItemChargeId("debtItemChargeId"),
+          mainTrans = "1525",
+          subTrans = "1000",
+          originalDebtAmount = 100,
+          interestStartDate = Some(LocalDate.parse("2010-02-02")),
+          List(Payment(LocalDate.parse("2020-01-01"), 100)),
+          dueDate = None,
+          chargeSource = None,
+          parentChargeReference = None,
+          parentMainTrans = None
+        )
+      ),
+      List(PaymentInformation(PaymentMethod.Bacs, Some(PaymentReference("ref123")))),
+      List(CustomerPostCode(PostCode("NW1 AB1"), postcodeDate = LocalDate.parse("2010-02-02"))),
+      List(
+        Instalment(
+          DebtItemChargeId("id1"),
+          dueDate = LocalDate.parse("2010-02-02"),
+          amountDue = 100,
+          expectedPayment = 100,
+          interestRate = 0.24,
+          instalmentNumber = 1,
+          instalmentInterestAccrued = 10,
+          instalmentBalance = 90
+        )
+      ),
+      regimeType = None
+    )
+
+    "should propagate a correlationId to TTP when it's provided one in the request" in {
+      stubRequest(
+        httpMethod = POST,
+        url = "/debts/time-to-pay/quote/arrangement",
+        status = 200,
+        responseBody = ""
+      )
+
+      val request: WSRequest =
+        buildRequest("/quote/arrangement")
+          .withHttpHeaders("correlationId" -> testCorrelationId)
+
+      await(
+        request.post(Json.toJson(createPlanRequest))
+      )
+
+      verify(
+        postRequestedFor(urlEqualTo("/debts/time-to-pay/quote/arrangement"))
+          .withHeader("correlationId", equalTo(testCorrelationId))
+      )
+    }
+
+    "should generate a new correlationId to send to TTP when it's not provided in the request" in {
+      stubRequest(
+        httpMethod = POST,
+        url = "/debts/time-to-pay/quote/arrangement",
+        status = 200,
+        responseBody = ""
+      )
+
+      val request: WSRequest = buildRequest("/quote/arrangement")
+
+      request.header("correlationId") shouldBe None
+
+      await(
+        request.post(Json.toJson(createPlanRequest))
+      )
+
+      verify(
+        postRequestedFor(urlEqualTo("/debts/time-to-pay/quote/arrangement"))
+          .withHeader("correlationId", matching(uuidRegex))
+          .withHeader("correlationId", WireMock.not(equalTo(testCorrelationId)))
+      )
+    }
+  }
+
   ".AAAAAAA" - {
     "should propagate a correlationId to TTP when it's provided one in the request" in {
 

--- a/it/test/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyControllerCorrelationIdItSpec.scala
+++ b/it/test/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyControllerCorrelationIdItSpec.scala
@@ -24,15 +24,17 @@ import play.api.libs.json.Json
 import play.api.libs.ws.WSRequest
 import uk.gov.hmrc.timetopayproxy.models._
 import uk.gov.hmrc.timetopayproxy.models.affordablequotes.AffordableQuotesRequest
+import uk.gov.hmrc.timetopayproxy.models.currency.GbpPounds
 import uk.gov.hmrc.timetopayproxy.models.saonly.chargeInfoApi.{ChargeInfoChannelIdentifier, ChargeInfoRequest}
-import uk.gov.hmrc.timetopayproxy.models.saonly.common.SaOnlyRegimeType
+import uk.gov.hmrc.timetopayproxy.models.saonly.common.{ArrangementAgreedDate, ChargeSourceSAOnly, DebtItemChargeReference, InitialPaymentDate, SaOnlyInstalment, SaOnlyRegimeType, TransitionedIndicator, TtpEndDate}
+import uk.gov.hmrc.timetopayproxy.models.saonly.ttpcancel.{CancellationDate, TtpCancelPaymentPlanR2, TtpCancelRequestR2}
 import uk.gov.hmrc.timetopayproxy.support.IntegrationBaseSpec
 
 import java.time.LocalDate
 import java.util.UUID
 
 class TimeToPayProxyControllerCorrelationIdItSpec extends IntegrationBaseSpec {
-  def internalAuthEnabled: Boolean = false
+  def internalAuthEnabled: Boolean = true
   def enrolmentAuthEnabled: Boolean = false
   def saRelease2Enabled: Boolean = true
 
@@ -446,6 +448,93 @@ class TimeToPayProxyControllerCorrelationIdItSpec extends IntegrationBaseSpec {
 
       verify(
         postRequestedFor(urlEqualTo("/debts/time-to-pay/charge-info"))
+          .withHeader("correlationId", matching(uuidRegex))
+          .withHeader("correlationId", WireMock.not(equalTo(testCorrelationId)))
+      )
+    }
+  }
+
+  ".cancelTtp" - {
+    val cancelRequest: TtpCancelRequestR2 =
+      TtpCancelRequestR2(
+        identifications = NonEmptyList.of(
+          Identification(
+            idType = IdType("idtype"),
+            idValue = IdValue("idvalue")
+          )
+        ),
+        paymentPlan = TtpCancelPaymentPlanR2(
+          arrangementAgreedDate = Some(ArrangementAgreedDate(LocalDate.parse("2020-01-02"))),
+          ttpEndDate = Some(TtpEndDate(LocalDate.parse("2020-02-04"))),
+          frequency = Some(FrequencyLowercase.Weekly),
+          cancellationDate = CancellationDate(LocalDate.parse("2020-03-05")),
+          initialPaymentDate = Some(InitialPaymentDate(LocalDate.parse("2020-04-06"))),
+          initialPaymentAmount = Some(GbpPounds.createOrThrow(100.12)),
+          debtItemCharges = NonEmptyList.of(
+            DebtItemChargeReference(
+              debtItemChargeId = DebtItemChargeId("ETMP001"),
+              chargeSource = ChargeSourceSAOnly.ETMP
+            ),
+            DebtItemChargeReference(
+              debtItemChargeId = DebtItemChargeId("CESA001"),
+              chargeSource = ChargeSourceSAOnly.CESA
+            ),
+            DebtItemChargeReference(
+              debtItemChargeId = DebtItemChargeId("ETMP002"),
+              chargeSource = ChargeSourceSAOnly.ETMP
+            )
+          )
+        ),
+        instalments = NonEmptyList.of(
+          SaOnlyInstalment(
+            dueDate = InstalmentDueDate(LocalDate.parse("2020-05-07")),
+            amountDue = GbpPounds.createOrThrow(200.34)
+          )
+        ),
+        channelIdentifier = ChannelIdentifier.SelfService,
+        transitioned = Some(TransitionedIndicator(true))
+      )
+
+    "should propagate a correlationId to TTP when it's provided one in the request" in {
+      stubRequest(
+        httpMethod = POST,
+        url = "/debts/time-to-pay/cancel",
+        status = 200,
+        responseBody = ""
+      )
+
+      val request: WSRequest =
+        buildRequest("/cancel")
+          .withHttpHeaders("correlationId" -> testCorrelationId)
+
+      await(
+        request.post(Json.toJson(cancelRequest))
+      )
+
+      verify(
+        postRequestedFor(urlEqualTo("/debts/time-to-pay/cancel"))
+          .withHeader("correlationId", equalTo(testCorrelationId))
+      )
+    }
+
+    "should generate a new correlationId to send to TTP when it's not provided in the request" in {
+      stubRequest(
+        httpMethod = POST,
+        url = "/debts/time-to-pay/cancel",
+        status = 200,
+        responseBody = ""
+      )
+
+      val request: WSRequest = buildRequest("/cancel")
+
+      request.header("correlationId") shouldBe None
+
+      await(
+        request.post(Json.toJson(cancelRequest))
+      )
+
+      verify(
+        postRequestedFor(urlEqualTo("/debts/time-to-pay/cancel"))
           .withHeader("correlationId", matching(uuidRegex))
           .withHeader("correlationId", WireMock.not(equalTo(testCorrelationId)))
       )

--- a/it/test/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyControllerCorrelationIdItSpec.scala
+++ b/it/test/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyControllerCorrelationIdItSpec.scala
@@ -26,8 +26,9 @@ import uk.gov.hmrc.timetopayproxy.models._
 import uk.gov.hmrc.timetopayproxy.models.affordablequotes.AffordableQuotesRequest
 import uk.gov.hmrc.timetopayproxy.models.currency.GbpPounds
 import uk.gov.hmrc.timetopayproxy.models.saonly.chargeInfoApi.{ChargeInfoChannelIdentifier, ChargeInfoRequest}
-import uk.gov.hmrc.timetopayproxy.models.saonly.common.{ArrangementAgreedDate, ChargeSourceSAOnly, DebtItemChargeReference, InitialPaymentDate, SaOnlyInstalment, SaOnlyRegimeType, TransitionedIndicator, TtpEndDate}
+import uk.gov.hmrc.timetopayproxy.models.saonly.common.{ArrangementAgreedDate, ChargeSourceSAOnly, DdiReference, DebtItemChargeReference, InitialPaymentDate, SaOnlyInstalment, SaOnlyPaymentPlan, SaOnlyRegimeType, TransitionedIndicator, TtpEndDate}
 import uk.gov.hmrc.timetopayproxy.models.saonly.ttpcancel.{CancellationDate, TtpCancelPaymentPlanR2, TtpCancelRequestR2}
+import uk.gov.hmrc.timetopayproxy.models.saonly.ttpinform.TtpInformRequest
 import uk.gov.hmrc.timetopayproxy.support.IntegrationBaseSpec
 
 import java.time.LocalDate
@@ -535,6 +536,83 @@ class TimeToPayProxyControllerCorrelationIdItSpec extends IntegrationBaseSpec {
 
       verify(
         postRequestedFor(urlEqualTo("/debts/time-to-pay/cancel"))
+          .withHeader("correlationId", matching(uuidRegex))
+          .withHeader("correlationId", WireMock.not(equalTo(testCorrelationId)))
+      )
+    }
+  }
+
+  ".informTtp" - {
+    val informRequest: TtpInformRequest =
+      TtpInformRequest(
+        identifications = NonEmptyList.of(
+          Identification(
+            idType = IdType("idtype"),
+            idValue = IdValue("idvalue")
+          )
+        ),
+        paymentPlan = SaOnlyPaymentPlan(
+          arrangementAgreedDate = ArrangementAgreedDate(LocalDate.parse("2020-01-02")),
+          ttpEndDate = TtpEndDate(LocalDate.parse("2020-02-04")),
+          frequency = FrequencyLowercase.Weekly,
+          initialPaymentDate = Some(InitialPaymentDate(LocalDate.parse("2020-04-06"))),
+          initialPaymentAmount = Some(GbpPounds.createOrThrow(100.12)),
+          ddiReference = Some(DdiReference("TestDDIReference")),
+          debtItemCharges = NonEmptyList.of(
+            DebtItemChargeReference(DebtItemChargeId("cesa-charge"), ChargeSourceSAOnly.CESA),
+            DebtItemChargeReference(DebtItemChargeId("etmp-charge"), ChargeSourceSAOnly.ETMP)
+          )
+        ),
+        instalments = NonEmptyList.of(
+          SaOnlyInstalment(
+            dueDate = InstalmentDueDate(LocalDate.parse("2020-05-07")),
+            amountDue = GbpPounds.createOrThrow(200.34)
+          )
+        ),
+        channelIdentifier = ChannelIdentifier.SelfService,
+        transitioned = Some(TransitionedIndicator(true))
+      )
+
+    "should propagate a correlationId to TTP when it's provided one in the request" in {
+      stubRequest(
+        httpMethod = POST,
+        url = "/debts/time-to-pay/inform",
+        status = 200,
+        responseBody = ""
+      )
+
+      val request: WSRequest =
+        buildRequest("/inform")
+          .withHttpHeaders("correlationId" -> testCorrelationId)
+
+      await(
+        request.post(Json.toJson(informRequest))
+      )
+
+      verify(
+        postRequestedFor(urlEqualTo("/debts/time-to-pay/inform"))
+          .withHeader("correlationId", equalTo(testCorrelationId))
+      )
+    }
+
+    "should generate a new correlationId to send to TTP when it's not provided in the request" in {
+      stubRequest(
+        httpMethod = POST,
+        url = "/debts/time-to-pay/inform",
+        status = 200,
+        responseBody = ""
+      )
+
+      val request: WSRequest = buildRequest("/inform")
+
+      request.header("correlationId") shouldBe None
+
+      await(
+        request.post(Json.toJson(informRequest))
+      )
+
+      verify(
+        postRequestedFor(urlEqualTo("/debts/time-to-pay/inform"))
           .withHeader("correlationId", matching(uuidRegex))
           .withHeader("correlationId", WireMock.not(equalTo(testCorrelationId)))
       )

--- a/it/test/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyControllerCorrelationIdItSpec.scala
+++ b/it/test/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyControllerCorrelationIdItSpec.scala
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.timetopayproxy.controllers
+
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.client.WireMock._
+import com.github.tomakehurst.wiremock.http.RequestMethod.POST
+import play.api.libs.json.Json
+import play.api.libs.ws.WSRequest
+import uk.gov.hmrc.timetopayproxy.models._
+import uk.gov.hmrc.timetopayproxy.support.IntegrationBaseSpec
+
+import java.time.LocalDate
+import java.util.UUID
+
+class TimeToPayProxyControllerCorrelationIdItSpec extends IntegrationBaseSpec {
+  def internalAuthEnabled: Boolean = false
+  def enrolmentAuthEnabled: Boolean = false
+  def saRelease2Enabled: Boolean = true
+
+  val testCorrelationId: String = UUID.randomUUID().toString
+  val uuidRegex: String = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+
+  ".generateQuote" - {
+    val generateQuoteRequest = GenerateQuoteRequest(
+      CustomerReference("CustRef1234"),
+      ChannelIdentifier.Advisor,
+      PlanToGenerateQuote(
+        QuoteType.Duration,
+        LocalDate.now(),
+        LocalDate.now(),
+        Some(5),
+        Some(FrequencyLowercase.TwoWeekly),
+        None,
+        Some(1),
+        None,
+        PaymentPlanType.TimeToPay
+      ),
+      List.empty,
+      List.empty,
+      regimeType = None
+    )
+
+    "should propagate a correlationId to TTP when it's provided one in the request" in {
+      stubRequest(
+        httpMethod = POST,
+        url = "/debts/time-to-pay/quote",
+        status = 200,
+        responseBody = ""
+      )
+
+      val request: WSRequest = buildRequest("/quote").withHttpHeaders("correlationId" -> testCorrelationId)
+
+      await(
+        request.post(Json.toJson(generateQuoteRequest))
+      )
+
+      verify(
+        postRequestedFor(urlEqualTo("/debts/time-to-pay/quote"))
+          .withHeader("correlationId", equalTo(testCorrelationId))
+      )
+    }
+
+    "should generate a new correlationId to send to TTP when it's not provided in the request" in {
+      stubRequest(
+        httpMethod = POST,
+        url = "/debts/time-to-pay/quote",
+        status = 200,
+        responseBody = ""
+      )
+
+      val request: WSRequest = buildRequest("/quote")
+
+      request.header("correlationId") shouldBe None
+
+      await(
+        request.post(Json.toJson(generateQuoteRequest))
+      )
+
+      verify(
+        postRequestedFor(urlEqualTo("/debts/time-to-pay/quote"))
+          .withHeader("correlationId", matching(uuidRegex))
+          .withHeader("correlationId", WireMock.not(equalTo(testCorrelationId)))
+      )
+    }
+  }
+}

--- a/it/test/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyControllerCorrelationIdItSpec.scala
+++ b/it/test/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyControllerCorrelationIdItSpec.scala
@@ -16,6 +16,7 @@
 
 package uk.gov.hmrc.timetopayproxy.controllers
 
+import cats.data.NonEmptyList
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock._
 import com.github.tomakehurst.wiremock.http.RequestMethod.{GET, POST, PUT}
@@ -23,6 +24,8 @@ import play.api.libs.json.Json
 import play.api.libs.ws.WSRequest
 import uk.gov.hmrc.timetopayproxy.models._
 import uk.gov.hmrc.timetopayproxy.models.affordablequotes.AffordableQuotesRequest
+import uk.gov.hmrc.timetopayproxy.models.saonly.chargeInfoApi.{ChargeInfoChannelIdentifier, ChargeInfoRequest}
+import uk.gov.hmrc.timetopayproxy.models.saonly.common.SaOnlyRegimeType
 import uk.gov.hmrc.timetopayproxy.support.IntegrationBaseSpec
 
 import java.time.LocalDate
@@ -387,6 +390,62 @@ class TimeToPayProxyControllerCorrelationIdItSpec extends IntegrationBaseSpec {
 
       verify(
         postRequestedFor(urlEqualTo("/debts/time-to-pay/affordability/affordable-quotes"))
+          .withHeader("correlationId", matching(uuidRegex))
+          .withHeader("correlationId", WireMock.not(equalTo(testCorrelationId)))
+      )
+    }
+  }
+
+  ".checkChargeInfo" - {
+    val chargeInfoRequest: ChargeInfoRequest = ChargeInfoRequest(
+      channelIdentifier = ChargeInfoChannelIdentifier("Channel Identifier"),
+      identifications = NonEmptyList.of(
+        Identification(idType = IdType("id type 1"), idValue = IdValue("id value 1")),
+        Identification(idType = IdType("id type 2"), idValue = IdValue("id value 2"))
+      ),
+      regimeType = SaOnlyRegimeType.SA
+    )
+
+    "should propagate a correlationId to TTP when it's provided one in the request" in {
+      stubRequest(
+        httpMethod = POST,
+        url = "/debts/time-to-pay/charge-info",
+        status = 200,
+        responseBody = ""
+      )
+
+      val request: WSRequest =
+        buildRequest("/charge-info")
+          .withHttpHeaders("correlationId" -> testCorrelationId)
+
+      await(
+        request.post(Json.toJson(chargeInfoRequest))
+      )
+
+      verify(
+        postRequestedFor(urlEqualTo("/debts/time-to-pay/charge-info"))
+          .withHeader("correlationId", equalTo(testCorrelationId))
+      )
+    }
+
+    "should generate a new correlationId to send to TTP when it's not provided in the request" in {
+      stubRequest(
+        httpMethod = POST,
+        url = "/debts/time-to-pay/charge-info",
+        status = 200,
+        responseBody = ""
+      )
+
+      val request: WSRequest = buildRequest("/charge-info")
+
+      request.header("correlationId") shouldBe None
+
+      await(
+        request.post(Json.toJson(chargeInfoRequest))
+      )
+
+      verify(
+        postRequestedFor(urlEqualTo("/debts/time-to-pay/charge-info"))
           .withHeader("correlationId", matching(uuidRegex))
           .withHeader("correlationId", WireMock.not(equalTo(testCorrelationId)))
       )

--- a/it/test/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyControllerCorrelationIdItSpec.scala
+++ b/it/test/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyControllerCorrelationIdItSpec.scala
@@ -22,6 +22,7 @@ import com.github.tomakehurst.wiremock.http.RequestMethod.{GET, POST, PUT}
 import play.api.libs.json.Json
 import play.api.libs.ws.WSRequest
 import uk.gov.hmrc.timetopayproxy.models._
+import uk.gov.hmrc.timetopayproxy.models.affordablequotes.AffordableQuotesRequest
 import uk.gov.hmrc.timetopayproxy.support.IntegrationBaseSpec
 
 import java.time.LocalDate
@@ -308,6 +309,84 @@ class TimeToPayProxyControllerCorrelationIdItSpec extends IntegrationBaseSpec {
 
       verify(
         postRequestedFor(urlEqualTo("/debts/time-to-pay/quote/arrangement"))
+          .withHeader("correlationId", matching(uuidRegex))
+          .withHeader("correlationId", WireMock.not(equalTo(testCorrelationId)))
+      )
+    }
+  }
+
+  ".getAffordableQuotes" - {
+    val affordableQuotesRequest: AffordableQuotesRequest = AffordableQuotesRequest(
+      channelIdentifier = "eSSTTP",
+      paymentPlanAffordableAmount = 500,
+      paymentPlanFrequency = FrequencyCapitalised.Monthly,
+      paymentPlanMaxLength = Duration(6),
+      paymentPlanMinLength = Duration(1),
+      accruedDebtInterest = 500,
+      paymentPlanStartDate = LocalDate.parse("2022-02-02"),
+      initialPaymentDate = Some(LocalDate.parse("2022-02-02")),
+      initialPaymentAmount = Some(500),
+      debtItemCharges = List(
+        DebtItemChargeSelfServe(
+          outstandingDebtAmount = 100000,
+          mainTrans = "1525",
+          subTrans = "1000",
+          DebtItemChargeId("ChargeRef 0903_2"),
+          interestStartDate = Some(LocalDate.parse("2021-09-03")),
+          debtItemOriginalDueDate = LocalDate.parse("2010-02-02"),
+          IsInterestBearingCharge(true),
+          UseChargeReference(false)
+        )
+      ),
+      customerPostcodes = List(
+        CustomerPostCode(
+          PostCode("some postcode"),
+          LocalDate.parse("2022-03-09")
+        )
+      ),
+      regimeType = Some(SsttpRegimeType.SA)
+    )
+
+    "should propagate a correlationId to TTP when it's provided one in the request" in {
+      stubRequest(
+        httpMethod = POST,
+        url = "/debts/time-to-pay/affordability/affordable-quotes",
+        status = 200,
+        responseBody = ""
+      )
+
+      val request: WSRequest =
+        buildRequest("/self-serve/affordable-quotes")
+          .withHttpHeaders("correlationId" -> testCorrelationId)
+
+      await(
+        request.post(Json.toJson(affordableQuotesRequest))
+      )
+
+      verify(
+        postRequestedFor(urlEqualTo("/debts/time-to-pay/affordability/affordable-quotes"))
+          .withHeader("correlationId", equalTo(testCorrelationId))
+      )
+    }
+
+    "should generate a new correlationId to send to TTP when it's not provided in the request" in {
+      stubRequest(
+        httpMethod = POST,
+        url = "/debts/time-to-pay/affordability/affordable-quotes",
+        status = 200,
+        responseBody = ""
+      )
+
+      val request: WSRequest = buildRequest("/self-serve/affordable-quotes")
+
+      request.header("correlationId") shouldBe None
+
+      await(
+        request.post(Json.toJson(affordableQuotesRequest))
+      )
+
+      verify(
+        postRequestedFor(urlEqualTo("/debts/time-to-pay/affordability/affordable-quotes"))
           .withHeader("correlationId", matching(uuidRegex))
           .withHeader("correlationId", WireMock.not(equalTo(testCorrelationId)))
       )

--- a/it/test/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyControllerCorrelationIdItSpec.scala
+++ b/it/test/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyControllerCorrelationIdItSpec.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.timetopayproxy.controllers
 
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock._
-import com.github.tomakehurst.wiremock.http.RequestMethod.{GET,POST}
+import com.github.tomakehurst.wiremock.http.RequestMethod.{GET, POST, PUT}
 import play.api.libs.json.Json
 import play.api.libs.ws.WSRequest
 import uk.gov.hmrc.timetopayproxy.models._
@@ -139,6 +139,73 @@ class TimeToPayProxyControllerCorrelationIdItSpec extends IntegrationBaseSpec {
 
       verify(
         getRequestedFor(urlEqualTo(s"/debts/time-to-pay/quote/$customerReference/$planId"))
+          .withHeader("correlationId", matching(uuidRegex))
+          .withHeader("correlationId", WireMock.not(equalTo(testCorrelationId)))
+      )
+    }
+  }
+
+  ".updatePlan" - {
+    val customerReference = "testCustomerReference"
+    val planId = "testPlanId"
+
+    val updatePlanRequest: UpdatePlanRequest =
+      UpdatePlanRequest(
+        CustomerReference(customerReference),
+        PlanId(planId),
+        UpdateType("updateType"),
+        channelIdentifier = None,
+        Some(PlanStatus.Success),
+        completeReason = None,
+        Some(CancellationReason("reason")),
+        thirdPartyBank = Some(true),
+        payments = Some(
+          List(
+            PaymentInformation(PaymentMethod.Bacs, Some(PaymentReference("reference")))
+          )
+        )
+      )
+
+    "should propagate a correlationId to TTP when it's provided one in the request" in {
+      stubRequest(
+        httpMethod = PUT,
+        url = s"/debts/time-to-pay/quote/$customerReference/$planId",
+        status = 200,
+        responseBody = ""
+      )
+
+      val request: WSRequest =
+        buildRequest(s"/quote/$customerReference/$planId")
+          .withHttpHeaders("correlationId" -> testCorrelationId)
+
+      await(
+        request.put(Json.toJson(updatePlanRequest))
+      )
+
+      verify(
+        putRequestedFor(urlEqualTo(s"/debts/time-to-pay/quote/$customerReference/$planId"))
+          .withHeader("correlationId", equalTo(testCorrelationId))
+      )
+    }
+
+    "should generate a new correlationId to send to TTP when it's not provided in the request" in {
+      stubRequest(
+        httpMethod = PUT,
+        url = s"/debts/time-to-pay/quote/$customerReference/$planId",
+        status = 200,
+        responseBody = ""
+      )
+
+      val request: WSRequest = buildRequest(s"/quote/$customerReference/$planId")
+
+      request.header("correlationId") shouldBe None
+
+      await(
+        request.put(Json.toJson(updatePlanRequest))
+      )
+
+      verify(
+        putRequestedFor(urlEqualTo(s"/debts/time-to-pay/quote/$customerReference/$planId"))
           .withHeader("correlationId", matching(uuidRegex))
           .withHeader("correlationId", WireMock.not(equalTo(testCorrelationId)))
       )

--- a/test/uk/gov/hmrc/timetopayproxy/actions/auth/ReadAuthoriseActionSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/actions/auth/ReadAuthoriseActionSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.timetopayproxy.auth
+package uk.gov.hmrc.timetopayproxy.actions.auth
 
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.freespec.AnyFreeSpec

--- a/test/uk/gov/hmrc/timetopayproxy/actions/correlationid/CorrelationIdPopulationActionSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/actions/correlationid/CorrelationIdPopulationActionSpec.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.timetopayproxy.actions.correlationid
 
 import ch.qos.logback.classic.spi.ILoggingEvent
-import ch.qos.logback.classic.{Level, Logger}
+import ch.qos.logback.classic.{ Level, Logger }
 import ch.qos.logback.core.read.ListAppender
 import org.scalatest.concurrent.ScalaFutures.convertScalaFuture
 import org.scalatest.freespec.AnyFreeSpec
@@ -44,11 +44,10 @@ class CorrelationIdPopulationActionSpec extends AnyFreeSpec {
     appender.start()
     logger.addAppender(appender)
 
-    try {
+    try
       body(appender)
-    } finally {
+    finally
       logger.detachAppender(appender)
-    }
   }
 
   val testCorrelationIdPopulationAction = new TestCorrelationIdPopulationAction()
@@ -86,18 +85,20 @@ class CorrelationIdPopulationActionSpec extends AnyFreeSpec {
           maybeGeneratedCorrelationId should not be None
           maybeGeneratedCorrelationId.get should fullyMatch regex "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
 
-          val generatedCorrelationId = maybeGeneratedCorrelationId.getOrElse(fail("Generated correlationId was somehow None after assertion"))
+          val generatedCorrelationId =
+            maybeGeneratedCorrelationId.getOrElse(fail("Generated correlationId was somehow None after assertion"))
 
           val logs = appender.list.asScala
-          logs.exists(event => {
-
+          logs.exists { event =>
             // Duplicate assertions here because the shouldBe true at the bottom doesn't point to what exactly failed
             event.getLevel shouldBe Level.WARN
             event.getFormattedMessage shouldBe s"[CORRELATION ID] Not found in request header for $requestUri, generated new correlationId: $generatedCorrelationId"
 
             event.getLevel == Level.WARN &&
-              event.getFormattedMessage.contains(s"[CORRELATION ID] Not found in request header for $requestUri, generated new correlationId: $generatedCorrelationId")
-          }) shouldBe true
+            event.getFormattedMessage.contains(
+              s"[CORRELATION ID] Not found in request header for $requestUri, generated new correlationId: $generatedCorrelationId"
+            )
+          } shouldBe true
           // This assertion of shouldBe true makes sure that the log actually happened
         }
       }

--- a/test/uk/gov/hmrc/timetopayproxy/actions/correlationid/CorrelationIdPopulationActionSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/actions/correlationid/CorrelationIdPopulationActionSpec.scala
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2026 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.timetopayproxy.actions.correlationid
+
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.classic.{Level, Logger}
+import ch.qos.logback.core.read.ListAppender
+import org.scalatest.concurrent.ScalaFutures.convertScalaFuture
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers._
+import org.slf4j.LoggerFactory
+import play.api.mvc.Request
+import play.api.test.FakeRequest
+
+import java.util.UUID
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.jdk.CollectionConverters.ListHasAsScala
+
+class CorrelationIdPopulationActionSpec extends AnyFreeSpec {
+
+  class TestCorrelationIdPopulationAction extends CorrelationIdPopulationAction() {
+    def transformPublic[A](request: Request[A]): Future[Request[A]] = transform(request)
+  }
+
+  def testWithLoggingCapture[A](body: ListAppender[ILoggingEvent] => A): A = {
+    val logger = LoggerFactory.getLogger(classOf[TestCorrelationIdPopulationAction]).asInstanceOf[Logger]
+    val appender = new ListAppender[ILoggingEvent]()
+
+    appender.start()
+    logger.addAppender(appender)
+
+    try {
+      body(appender)
+    } finally {
+      logger.detachAppender(appender)
+    }
+  }
+
+  val testCorrelationIdPopulationAction = new TestCorrelationIdPopulationAction()
+
+  "CorrelationIdPopulationAction" - {
+    ".transform" - {
+      "use an existing correlationId when provided one in the request" - {
+        "adhering to case sensitivity" in {
+          val testCorrelationId = UUID.randomUUID().toString
+
+          val request = FakeRequest().withHeaders("correlationId" -> testCorrelationId)
+          val result = testCorrelationIdPopulationAction.transformPublic(request).futureValue
+
+          result.headers.get("correlationId") shouldBe Some(testCorrelationId)
+        }
+
+        "not adhering to case sensitivity" in {
+          val testCorrelationId = UUID.randomUUID().toString
+
+          val request = FakeRequest().withHeaders("CORreLaTioNiD" -> testCorrelationId)
+          val result = testCorrelationIdPopulationAction.transformPublic(request).futureValue
+
+          result.headers.get("correlationId") shouldBe Some(testCorrelationId)
+        }
+      }
+
+      "log and generate a new correlationId when not provided in the request" in {
+        val requestUri = "/test/uri"
+        val request = FakeRequest(method = "GET", path = requestUri)
+
+        testWithLoggingCapture { appender =>
+          val result = testCorrelationIdPopulationAction.transformPublic(request).futureValue
+
+          val maybeGeneratedCorrelationId = result.headers.get("correlationId")
+          maybeGeneratedCorrelationId should not be None
+          maybeGeneratedCorrelationId.get should fullyMatch regex "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+
+          val generatedCorrelationId = maybeGeneratedCorrelationId.getOrElse(fail("Generated correlationId was somehow None after assertion"))
+
+          val logs = appender.list.asScala
+          logs.exists(event => {
+
+            // Duplicate assertions here because the shouldBe true at the bottom doesn't point to what exactly failed
+            event.getLevel shouldBe Level.WARN
+            event.getFormattedMessage shouldBe s"[CORRELATION ID] Not found in request header for $requestUri, generated new correlationId: $generatedCorrelationId"
+
+            event.getLevel == Level.WARN &&
+              event.getFormattedMessage.contains(s"[CORRELATION ID] Not found in request header for $requestUri, generated new correlationId: $generatedCorrelationId")
+          }) shouldBe true
+          // This assertion of shouldBe true makes sure that the log actually happened
+        }
+      }
+    }
+  }
+}

--- a/test/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyControllerSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyControllerSpec.scala
@@ -32,6 +32,7 @@ import uk.gov.hmrc.auth.core.retrieve.{ EmptyRetrieval, Retrieval }
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.timetopayproxy.actions.auth.ReadAuthoriseAction
 import uk.gov.hmrc.timetopayproxy.actions.auth.StoredEnrolmentScope.ReadTimeToPayProxy
+import uk.gov.hmrc.timetopayproxy.actions.correlationid.CorrelationIdPopulationAction
 import uk.gov.hmrc.timetopayproxy.config.FeatureSwitch
 import uk.gov.hmrc.timetopayproxy.models._
 import uk.gov.hmrc.timetopayproxy.models.affordablequotes._
@@ -57,6 +58,7 @@ class TimeToPayProxyControllerSpec extends AnyWordSpec with MockFactory {
   private val cc: ControllerComponents = Helpers.stubControllerComponents()
   private val featureSwitch: FeatureSwitch = mock[FeatureSwitch]
 
+  private val correlationIdPopulationAction: CorrelationIdPopulationAction = new CorrelationIdPopulationAction()
   private val readAuthoriseAction: ReadAuthoriseAction =
     new ReadAuthoriseAction(authConnector, cc, featureSwitch)
 
@@ -65,6 +67,7 @@ class TimeToPayProxyControllerSpec extends AnyWordSpec with MockFactory {
   private val ttpFeedbackLoopService = mock[TtpFeedbackLoopService]
   private val controller =
     new TimeToPayProxyController(
+      correlationIdPopulationAction,
       readAuthoriseAction,
       cc,
       ttpQuoteService,


### PR DESCRIPTION
This PR:
- Introduces potential Correlation ID generation for all Proxy endpoints
- Makes sure that case sensitivity is handled
- Moves the Correlation ID generation away from the connector so that any logs and future logs should include a generated Correlation ID (if needed) right from the start
- Logs a warning when the Proxy doesn't receive a Correlation ID 