### PR TITLE
DTD-4481: Cucumber to scalaTest - Create unit / integration tests for TTP Proxy API repo shift left candidates (3)

### DIFF
--- a/test/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyControllerSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyControllerSpec.scala
@@ -534,6 +534,32 @@ class TimeToPayProxyControllerSpec extends AnyWordSpec with MockFactory {
       contentAsJson(response) shouldBe expectedResponseJson
     }
 
+    def runUpdatePlanTest(paymentMethod: PaymentMethod): Unit = {
+      val request = updatePlanRequest.copy(
+        payments = Some(
+          List(
+            PaymentInformation(paymentMethod, Some(PaymentReference("reference")))
+          )
+        )
+      )
+
+      val updatePlanResponse = UpdatePlanResponse(
+        CustomerReference("customerReference"),
+        PlanId("pageId"),
+        PlanStatus.Success,
+        LocalDate.now()
+      )
+
+      testControllerForPUT(
+        Json.toJson(request),
+        Status.OK,
+        Json.toJson(updatePlanResponse),
+        updatePlanRequest.customerReference.value,
+        updatePlanRequest.planId.value,
+        Some(TtppEnvelope(updatePlanResponse))
+      )
+    }
+
     "return 200" when {
       "service returns success" in {
         val updatePlanResponse: UpdatePlanResponse = UpdatePlanResponse(
@@ -554,6 +580,18 @@ class TimeToPayProxyControllerSpec extends AnyWordSpec with MockFactory {
           Some(ttpServiceResponse)
         )
       }
+
+      "when payment method is one of the supported values" in {
+        List(
+          PaymentMethod.Bacs,
+          PaymentMethod.BankPayments,
+          PaymentMethod.CardPayment,
+          PaymentMethod.Cheque,
+          PaymentMethod.DirectDebit,
+          PaymentMethod.OnGoingAward
+        ).foreach(runUpdatePlanTest)
+      }
+
       "when paymentMethod is not directDebit and paymentReference is missing" in {
         val updatePlanRequestMissingPaymentReference: UpdatePlanRequest =
           Json
@@ -834,6 +872,42 @@ class TimeToPayProxyControllerSpec extends AnyWordSpec with MockFactory {
             TtppErrorResponse(
               errorStatus,
               "Could not parse body due to requirement failed: Invalid UpdatePlanRequest payload: Payload has a missing field or an invalid format. Field name: planStatus."
+            )
+          ),
+          "custReference1234",
+          "planId1234",
+          ttpServiceResponse = None
+        )
+      }
+
+      "missing field paymentMethod when the updateType is paymentDetails" in {
+
+        val updatePlanRequestPaymentMethodMissing: JsValue =
+          Json.obj(
+            "customerReference" -> "custReference1234",
+            "planId"            -> "planId1234",
+            "updateType"        -> "paymentDetails",
+            "thirdPartyBank"    -> false,
+            "payments" ->
+              JsArray(
+                List(
+                  Json.obj(
+                    "paymentMethod"    -> "",
+                    "paymentReference" -> "paymentRef123"
+                  )
+                )
+              )
+          )
+
+        val errorStatus = Status.BAD_REQUEST
+
+        testControllerForPUT(
+          updatePlanRequestPaymentMethodMissing,
+          errorStatus,
+          Json.toJson(
+            TtppErrorResponse(
+              errorStatus,
+              "Invalid UpdatePlanRequest payload: Payload has a missing field or an invalid format. Field name: paymentMethod. Valid enum value should be provided"
             )
           ),
           "custReference1234",

--- a/test/uk/gov/hmrc/timetopayproxy/services/TTPEServiceSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/services/TTPEServiceSpec.scala
@@ -267,6 +267,25 @@ class TTPEServiceSpec extends AnyFreeSpec with MockFactory {
         message = "Internal server error"
       ).asLeft[ChargeInfoResponse]
     }
+
+    "returns an error 400 from the connector" in {
+      val connectorStub = new TtpeConnectorStub(
+        Left(
+          ConnectorError(
+            400,
+            "Dependent systems from interest-forecasting are currently not responding; statusCode: 400, description: An error was returned from upstream when calling IFS"
+          )
+        )
+      )
+
+      val ttpeService = new DefaultTTPEService(connectorStub)
+
+      await(ttpeService.checkChargeInfo(chargeInfoRequest).value) shouldBe ConnectorError(
+        statusCode = 400,
+        message =
+          "Dependent systems from interest-forecasting are currently not responding; statusCode: 400, description: An error was returned from upstream when calling IFS"
+      ).asLeft[ChargeInfoResponse]
+    }
   }
 }
 

--- a/test/uk/gov/hmrc/timetopayproxy/services/TTPQuoteServiceSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/services/TTPQuoteServiceSpec.scala
@@ -330,6 +330,43 @@ class TTPQuoteServiceSpec extends UnitSpec {
         .asRight[ProxyEnvelopeError]
     }
 
+    "return a quote when the service returns a successful response with different payment methods" in {
+
+      val paymentReference = PaymentReference("PaymentRef123")
+      val paymentMethods = Seq(
+        PaymentMethod.Bacs,
+        PaymentMethod.BankPayments,
+        PaymentMethod.CardPayment,
+        PaymentMethod.Cheque,
+        PaymentMethod.DirectDebit,
+        PaymentMethod.OnGoingAward
+      )
+
+      paymentMethods.foreach { paymentMethod: PaymentMethod =>
+        val retrievePlanWithPaymentInfo =
+          retrievePlanResponse.copy(payments = List(PaymentInformation(paymentMethod, Some(paymentReference))))
+
+        val connectorStub = new TtpConnectorStub(
+          Right(generateQuoteResponse),
+          Right(retrievePlanWithPaymentInfo),
+          Right(updatePlanResponse),
+          Right(createPlanResponse),
+          Right(affordableQuoteResponse)
+        )
+        val quoteService = new DefaultTTPQuoteService(connectorStub)
+
+        await(
+          quoteService
+            .getExistingPlan(
+              CustomerReference("someCustomer"),
+              PlanId("somePlanId")
+            )
+            .value
+        ) shouldBe retrievePlanWithPaymentInfo
+          .asRight[ProxyEnvelopeError]
+      }
+    }
+
     "return a error if the service does not return a successful response" in {
       val connectorStub = new TtpConnectorStub(
         Right(generateQuoteResponse),

--- a/test/uk/gov/hmrc/timetopayproxy/services/TTPQuoteServiceSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/services/TTPQuoteServiceSpec.scala
@@ -351,6 +351,28 @@ class TTPQuoteServiceSpec extends UnitSpec {
         .asLeft[ViewPlanResponse]
 
     }
+
+    "return a 400 error if the plan is not found" in {
+      val connectorStub = new TtpConnectorStub(
+        Right(generateQuoteResponse),
+        Left(ConnectorError(400, "No records found")),
+        Right(updatePlanResponse),
+        Right(createPlanResponse),
+        Right(affordableQuoteResponse)
+      )
+      val quoteService = new DefaultTTPQuoteService(connectorStub)
+
+      await(
+        quoteService
+          .getExistingPlan(
+            CustomerReference("someCustomer"),
+            PlanId("somePlanId")
+          )
+          .value
+      ) shouldBe ConnectorError(400, "No records found")
+        .asLeft[ViewPlanResponse]
+
+    }
   }
 
   "Update Quote endpoint" should {


### PR DESCRIPTION
Created unit tests for following ATs

1. - Get charge-info CESA and ETMP missing filtered charges returns 400 error
(In file **test/uk/gov/hmrc/timetopayproxy/services/TTPEServiceSpec.scala** and test is "returns an error 400 from the connector". Line 271)

2. - Update type status as paymentDetails -thirdPartyBank missing
(In file **test/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyControllerSpec.scala** and test is "missing field paymentMethod when the updateType is paymentDetails". Line 883)

3. - Update Payment Method 
(In file **test/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyControllerSpec.scala** and test is "when payment method is one of the supported values". Line 584)

4. - Should return error if plan ID number is invalid
(In file **test/uk/gov/hmrc/timetopayproxy/services/TTPQuoteServiceSpec.scala** and test is "return a 400 error if the plan is not found". Line 355)

Rest of the tests either need to be removed or kept as it is. I have already updated the Cucumber Migration - Tracker spreadsheet (https://docs.google.com/spreadsheets/d/1NqQT4u2fMNkjTmAB76gCiBo7FDOCYpLY58eVKqK5yU0/edit?gid=150723010#gid=150723010)