### PR TITLE
DTD-4649: Update definition.json to use new access system

### DIFF
--- a/it/test/uk/gov/hmrc/timetopayproxy/config/DocumentationControllerSpec.scala
+++ b/it/test/uk/gov/hmrc/timetopayproxy/config/DocumentationControllerSpec.scala
@@ -38,9 +38,7 @@ class DocumentationControllerSpec extends IntegrationBaseSpec {
       |    "versions": [
       |      {
       |        "version": "1.0",
-      |        "access": {
-      |          "type": "PRIVATE"
-      |        },
+      |        "access": "INTERNAL",
       |        "status": "BETA",
       |        "endpointsEnabled": true
       |      }

--- a/resources/public/api/definition.json
+++ b/resources/public/api/definition.json
@@ -6,9 +6,7 @@
     "versions": [
       {
         "version": "1.0",
-        "access": {
-          "type": "PRIVATE"
-        },
+        "access": "INTERNAL",
         "status": "BETA",
         "endpointsEnabled": true
       }


### PR DESCRIPTION
Remove deprecated access definition syntax.