### PR TITLE
DTD-4231: Update to scala 3

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,18 +1,10 @@
-version = 3.7.13
-runner.dialect = scala213
-style = defaultWithAlign
+version = "3.9.8"
+runner.dialect = scala3
 maxColumn = 120
 lineEndings = unix
 importSelectors = singleLine
 
-
-project {
-    git = true
-}
-
-
-align = none
-
+align.preset = none
 
 align {
     tokens = [ {code = "=>", owner = "Case|Type.Arg.ByName"}, "<-", "->", "%", "%%" ]
@@ -21,17 +13,14 @@ align {
     openParenDefnSite = false
 }
 
-
 binPack {
     parentConstructors = true
 }
-
 
 continuationIndent {
     callSite = 2
     defnSite = 2
 }
-
 
 docstrings {
     # `wrap` is a buggy "feature" that even they admit will not format all scaladocs correctly.
@@ -39,15 +28,15 @@ docstrings {
     wrap = no
 }
 
-
 newlines {
     penalizeSingleSelectMultiArgList = false
-    sometimesBeforeColonInMethodReturnType = true
+    avoidInResultType = true
 }
 
-
 rewrite {
-    rules = [RedundantBraces, RedundantParens, AsciiSortImports]
+    rules = [RedundantBraces, RedundantParens, Imports]
+    imports.sort = ascii
+
     redundantBraces {
         maxLines = 120
         includeUnitMethods = true
@@ -55,11 +44,9 @@ rewrite {
     }
 }
 
-
 spaces {
     inImportCurlyBraces = true
     beforeContextBoundColon = false
 }
-
 
 assumeStandardLibraryStripMargin = true

--- a/app/uk/gov/hmrc/timetopayproxy/actions/auth/AuthoriseAction.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/actions/auth/AuthoriseAction.scala
@@ -19,8 +19,8 @@ package uk.gov.hmrc.timetopayproxy.actions.auth
 import enumeratum.{ Enum, EnumEntry }
 import play.api.Logger
 import play.api.mvc.Results.{ Forbidden, ServiceUnavailable }
-import play.api.mvc._
-import uk.gov.hmrc.auth.core._
+import play.api.mvc.*
+import uk.gov.hmrc.auth.core.*
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.http.HeaderCarrierConverter
 import uk.gov.hmrc.timetopayproxy.config.FeatureSwitch

--- a/app/uk/gov/hmrc/timetopayproxy/connectors/TtpConnector.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/connectors/TtpConnector.scala
@@ -19,12 +19,13 @@ package uk.gov.hmrc.timetopayproxy.connectors
 import cats.data.EitherT
 import com.google.inject.ImplementedBy
 import play.api.libs.json.Json
+import play.api.libs.ws.writeableOf_JsValue
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.http.{ HeaderCarrier, HttpReads, StringContextOps }
 import uk.gov.hmrc.timetopayproxy.config.{ AppConfig, FeatureSwitch }
 import uk.gov.hmrc.timetopayproxy.connectors.util.httpreadsbuilder.HttpReadsBuilder
 import uk.gov.hmrc.timetopayproxy.logging.{ RequestAwareLogger, StatusLogger }
-import uk.gov.hmrc.timetopayproxy.models._
+import uk.gov.hmrc.timetopayproxy.models.*
 import uk.gov.hmrc.timetopayproxy.models.affordablequotes.{ AffordableQuoteResponse, AffordableQuotesRequest }
 import uk.gov.hmrc.timetopayproxy.models.error.ProxyEnvelopeError
 import uk.gov.hmrc.timetopayproxy.models.error.TtppEnvelope.TtppEnvelope
@@ -117,7 +118,7 @@ class DefaultTtpConnector @Inject() (appConfig: AppConfig, httpClient: HttpClien
         httpClient
           .post(url)
           .withBody(Json.toJson(ttppRequest))
-          .setHeader(combinedHeaders: _*)
+          .setHeader(combinedHeaders*)
           .execute[Either[ProxyEnvelopeError, GenerateQuoteResponse]]
       )
     ).logBasedOnStatusCode(logger)
@@ -139,7 +140,7 @@ class DefaultTtpConnector @Inject() (appConfig: AppConfig, httpClient: HttpClien
       EitherT(
         httpClient
           .get(url)
-          .setHeader(combinedHeaders: _*)
+          .setHeader(combinedHeaders*)
           .execute[Either[ProxyEnvelopeError, ViewPlanResponse]]
       )
     ).logBasedOnStatusCode(logger)
@@ -168,7 +169,7 @@ class DefaultTtpConnector @Inject() (appConfig: AppConfig, httpClient: HttpClien
         httpClient
           .put(url)
           .withBody(Json.toJson(updatePlanRequest))
-          .setHeader(combinedHeaders: _*)
+          .setHeader(combinedHeaders*)
           .execute[Either[ProxyEnvelopeError, UpdatePlanResponse]]
       )
     ).logBasedOnStatusCode(logger)
@@ -203,7 +204,7 @@ class DefaultTtpConnector @Inject() (appConfig: AppConfig, httpClient: HttpClien
         httpClient
           .post(url)
           .withBody(Json.toJson(createPlanRequest))
-          .setHeader(headers: _*)
+          .setHeader(headers*)
           .execute[Either[ProxyEnvelopeError, CreatePlanResponse]]
       )
     ).logBasedOnStatusCode(logger)
@@ -225,7 +226,7 @@ class DefaultTtpConnector @Inject() (appConfig: AppConfig, httpClient: HttpClien
         httpClient
           .post(url)
           .withBody(Json.toJson(affordableQuotesRequest))
-          .setHeader(combinedHeaders: _*)
+          .setHeader(combinedHeaders*)
           .execute[Either[ProxyEnvelopeError, AffordableQuoteResponse]]
       )
     ).logBasedOnStatusCode(logger)

--- a/app/uk/gov/hmrc/timetopayproxy/connectors/TtpFeedbackLoopConnector.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/connectors/TtpFeedbackLoopConnector.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.timetopayproxy.connectors
 
 import cats.data.EitherT
 import play.api.libs.json.Json
+import play.api.libs.ws.writeableOf_JsValue
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.http.{ HeaderCarrier, HttpReads, StringContextOps }
 import uk.gov.hmrc.timetopayproxy.config.{ AppConfig, FeatureSwitch }
@@ -87,7 +88,7 @@ class TtpFeedbackLoopConnector @Inject() (
         httpClient
           .post(url)
           .withBody(Json.toJson(ttppRequest))
-          .setHeader(requestHeaders: _*)
+          .setHeader(requestHeaders*)
           .execute[Either[ProxyEnvelopeError, TtpCancelSuccessfulResponse]]
       )
     ).logBasedOnStatusCode(logger)
@@ -109,7 +110,7 @@ class TtpFeedbackLoopConnector @Inject() (
         httpClient
           .post(url)
           .withBody(Json.toJson(ttppRequestR2))
-          .setHeader(requestHeaders: _*)
+          .setHeader(requestHeaders*)
           .execute[Either[ProxyEnvelopeError, TtpCancelSuccessfulResponse]]
       )
     ).logBasedOnStatusCode(logger)
@@ -131,7 +132,7 @@ class TtpFeedbackLoopConnector @Inject() (
         httpClient
           .post(url)
           .withBody(Json.toJson(request))
-          .setHeader(requestHeaders: _*)
+          .setHeader(requestHeaders*)
           .execute[Either[ProxyEnvelopeError, TtpFullAmendSuccessfulResponse]]
       )
     ).logBasedOnStatusCode(logger)
@@ -153,7 +154,7 @@ class TtpFeedbackLoopConnector @Inject() (
         httpClient
           .post(url)
           .withBody(Json.toJson(ttppInformRequest))
-          .setHeader(requestHeaders: _*)
+          .setHeader(requestHeaders*)
           .execute[Either[ProxyEnvelopeError, TtpInformSuccessfulResponse]]
       )
     ).logBasedOnStatusCode(logger)

--- a/app/uk/gov/hmrc/timetopayproxy/connectors/TtpTestConnector.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/connectors/TtpTestConnector.scala
@@ -20,7 +20,8 @@ import cats.implicits.catsSyntaxEitherId
 import com.google.inject.ImplementedBy
 import play.api.http.Status.{ NO_CONTENT, OK }
 import play.api.libs.json.Json
-import uk.gov.hmrc.http.HttpReads.Implicits._
+import play.api.libs.ws.writeableOf_JsValue
+import uk.gov.hmrc.http.HttpReads.Implicits.*
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.http.{ HeaderCarrier, HttpException, HttpResponse, StringContextOps, UpstreamErrorResponse }
 import uk.gov.hmrc.timetopayproxy.config.AppConfig

--- a/app/uk/gov/hmrc/timetopayproxy/connectors/TtpeConnector.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/connectors/TtpeConnector.scala
@@ -19,6 +19,7 @@ package uk.gov.hmrc.timetopayproxy.connectors
 import cats.data.EitherT
 import com.google.inject.ImplementedBy
 import play.api.libs.json.Json
+import play.api.libs.ws.writeableOf_JsValue
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.http.{ HeaderCarrier, HttpReads, StringContextOps }
 import uk.gov.hmrc.timetopayproxy.config.{ AppConfig, FeatureSwitch }
@@ -78,7 +79,7 @@ class DefaultTtpeConnector @Inject() (appConfig: AppConfig, httpClient: HttpClie
         httpClient
           .post(url)
           .withBody(Json.toJson(chargeInfoRequest))
-          .setHeader(requestHeaders: _*)
+          .setHeader(requestHeaders*)
           .execute[Either[ProxyEnvelopeError, ChargeInfoResponse]]
       )
     ).logBasedOnStatusCode(logger)

--- a/app/uk/gov/hmrc/timetopayproxy/connectors/util/httpreadsbuilder/HttpReadsBuilder.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/connectors/util/httpreadsbuilder/HttpReadsBuilder.scala
@@ -36,7 +36,7 @@ import uk.gov.hmrc.timetopayproxy.logging.RequestAwareLogger
  * The most complex features are required by time-to-pay, so that is the best place to test any refactoring.
  */
 final class HttpReadsBuilder[ServiceError, Result] private[httpreadsbuilder] (
-  sourceClass: Class[_],
+  sourceClass: Class[?],
   explicitHandlers: Map[Int, SingleStatusHandler[ServiceError, Result]],
   createConnectorError: HttpReadsBuilderError[ServiceError] => ServiceError
 ) {
@@ -164,7 +164,7 @@ object HttpReadsBuilder extends HttpReadsBuilderCompanionInterfaces {
     * @param converter Instance responsible for converting the internal builder errors into something the connector will understand.
     */
   def empty[ServiceError, Result](
-    sourceClass: Class[_],
+    sourceClass: Class[?],
     converter: HttpReadsBuilderErrorConverter[ServiceError]
   ): HttpReadsBuilder[ServiceError, Result] =
     new HttpReadsBuilder[ServiceError, Result](

--- a/app/uk/gov/hmrc/timetopayproxy/connectors/util/httpreadsbuilder/implcommontoallrepos/HttpReadsBuilderError.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/connectors/util/httpreadsbuilder/implcommontoallrepos/HttpReadsBuilderError.scala
@@ -91,7 +91,7 @@ private[httpreadsbuilder] object HttpReadsBuilderError {
   }
 
   /** Error created when the builder was never told to expect the received status code. */
-  final case class UnexpectedStatusCode(sourceClass: Class[_], responseContext: ResponseContext)
+  final case class UnexpectedStatusCode(sourceClass: Class[?], responseContext: ResponseContext)
       extends CentrallyImmplementedVariant {
 
     def whichEitherWasExpected: WhichEitherWasExpected = OriginallyMeantToBeLeft
@@ -101,7 +101,7 @@ private[httpreadsbuilder] object HttpReadsBuilderError {
 
   /** Error created when the builder was told to expect this status code, but the HTTP body was not JSON. */
   final case class ResponseBodyNotJson(
-    sourceClass: Class[_],
+    sourceClass: Class[?],
     responseContext: ResponseContext,
     whichEitherWasExpected: WhichEitherWasExpected,
     sensitiveException: Throwable
@@ -116,7 +116,7 @@ private[httpreadsbuilder] object HttpReadsBuilderError {
 
   /** Error created when the builder was told to expect this status code, but the HTTP body was the wrong JSON. */
   final case class ResponseBodyInvalidJsonStructure(
-    sourceClass: Class[_],
+    sourceClass: Class[?],
     responseContext: ResponseContext,
     whichEitherWasExpected: WhichEitherWasExpected,
     errs: Seq[(JsPath, Seq[JsonValidationError])]
@@ -140,7 +140,7 @@ private[httpreadsbuilder] object HttpReadsBuilderError {
 
   /** Error created when the builder was told to expect this status code, but we got a HTTP body without expecting one. */
   final case class ResponseBodyNotEmpty(
-    sourceClass: Class[_],
+    sourceClass: Class[?],
     responseContext: ResponseContext,
     whichEitherWasExpected: WhichEitherWasExpected
   ) extends CentrallyImmplementedVariant {

--- a/app/uk/gov/hmrc/timetopayproxy/connectors/util/httpreadsbuilder/implcommontoallrepos/LoggingContext.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/connectors/util/httpreadsbuilder/implcommontoallrepos/LoggingContext.scala
@@ -36,18 +36,18 @@ private[httpreadsbuilder] final class LoggingContext[-ServiceError](
   def logError(responseContext: ResponseContext, error: HttpReadsBuilderError.CentrallyImmplementedVariant): Unit =
     logger.error(
       s"""${error.prodSummaryAndDetail}
-         |Returning: ${makeErrorSafeToLogInProd(error)} .
-         |Request made for received HTTP response: ${responseContext.method} ${responseContext.url} .
-         |Received HTTP response status: ${responseContext.response.status}.
-         |${safeToLogResponseBodyDescription(responseContext.response)}""".stripMargin
+        |Returning: ${makeErrorSafeToLogInProd(error)} .
+        |Request made for received HTTP response: ${responseContext.method} ${responseContext.url} .
+        |Received HTTP response status: ${responseContext.response.status}.
+        |${safeToLogResponseBodyDescription(responseContext.response)}""".stripMargin
     )(hc)
 
   def logWarningAboutValidUnsuccessfulResponse(responseContext: ResponseContext): Unit =
     logger.warn(
       s"""Valid and expected error response was received from HTTP call.
-         |Request made for received HTTP response: ${responseContext.method} ${responseContext.url} .
-         |Received HTTP response status: ${responseContext.response.status}.
-         |${safeToLogResponseBodyDescription(responseContext.response)}""".stripMargin
+        |Request made for received HTTP response: ${responseContext.method} ${responseContext.url} .
+        |Received HTTP response status: ${responseContext.response.status}.
+        |${safeToLogResponseBodyDescription(responseContext.response)}""".stripMargin
     )(hc)
 
   private def safeToLogResponseBodyDescription(response: HttpResponse): String =

--- a/app/uk/gov/hmrc/timetopayproxy/connectors/util/httpreadsbuilder/implcommontoallrepos/SingleStatusHandler.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/connectors/util/httpreadsbuilder/implcommontoallrepos/SingleStatusHandler.scala
@@ -34,7 +34,7 @@ private[httpreadsbuilder] final case class SingleStatusHandler[+ServiceError, +R
 
 private[httpreadsbuilder] object SingleStatusHandler {
   def fallbackErrorForUnknownStatusCode[ServiceError](
-    sourceClass: Class[_]
+    sourceClass: Class[?]
   ): SingleStatusHandler[ServiceError, Nothing] =
     SingleStatusHandler { (responseContext, maybeLoggingContext) =>
       val error = HttpReadsBuilderError.UnexpectedStatusCode(sourceClass = sourceClass, responseContext)
@@ -44,7 +44,7 @@ private[httpreadsbuilder] object SingleStatusHandler {
     }
 
   def assumingNoBody[ServiceError, Result](
-    sourceClass: Class[_],
+    sourceClass: Class[?],
     value: Either[ServiceError, Result]
   ): SingleStatusHandler[ServiceError, Result] =
     SingleStatusHandler[ServiceError, Result] { (responseContext, maybeLoggingContext) =>
@@ -82,13 +82,13 @@ private[httpreadsbuilder] object SingleStatusHandler {
     }
 
   def assumingJsonSuccess[ServiceError, Result, ReadableResult: Reads](
-    sourceClass: Class[_],
+    sourceClass: Class[?],
     transform: ReadableResult => Result
   ): SingleStatusHandler[ServiceError, Result] =
     SingleStatusHandler { (responseContext, maybeLoggingContext) =>
       Try(responseContext.response.json).map(_.validate[ReadableResult]) match {
         case Success(JsSuccess(deserialisedBody, _)) => Right(transform(deserialisedBody))
-        case Success(JsError(errs)) =>
+        case Success(JsError(errs))                  =>
           val error = HttpReadsBuilderError.ResponseBodyInvalidJsonStructure(
             sourceClass = sourceClass,
             responseContext,
@@ -112,7 +112,7 @@ private[httpreadsbuilder] object SingleStatusHandler {
     }
 
   def assumingJsonError[Result, ReadableError: Reads, ServiceError](
-    sourceClass: Class[_],
+    sourceClass: Class[?],
     transform: ReadableError => ServiceError
   ): SingleStatusHandler[ServiceError, Result] =
     SingleStatusHandler { (responseContext, maybeLoggingContext: Option[LoggingContext[ServiceError]]) =>

--- a/app/uk/gov/hmrc/timetopayproxy/connectors/util/httpreadsbuilder/implrepospecific/HttpReadsBuilderCompanionInterfaces.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/connectors/util/httpreadsbuilder/implrepospecific/HttpReadsBuilderCompanionInterfaces.scala
@@ -23,7 +23,7 @@ private[httpreadsbuilder] trait HttpReadsBuilderCompanionInterfaces { this: Http
 
   /** See [[ConverterDefaultingTo503]] for what errors this `HttpReads` will generate. */
   def withDefault503ConnectorError[ServiceError >: ConverterDefaultingTo503.ServiceErrorLowerBound, Result](
-    sourceClass: Class[_]
+    sourceClass: Class[?]
   ): HttpReadsBuilder[ServiceError, Result] =
     HttpReadsBuilder.empty(
       sourceClass = sourceClass,

--- a/app/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyController.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyController.scala
@@ -16,16 +16,16 @@
 
 package uk.gov.hmrc.timetopayproxy.controllers
 
-import cats.syntax.either._
-import play.api.libs.json._
-import play.api.mvc._
+import cats.syntax.either.*
+import play.api.libs.json.*
+import play.api.mvc.*
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 import uk.gov.hmrc.timetopayproxy.actions.auth.ReadAuthoriseAction
 import uk.gov.hmrc.timetopayproxy.actions.correlationid.CorrelationIdPopulationAction
 import uk.gov.hmrc.timetopayproxy.config.FeatureSwitch
 import uk.gov.hmrc.timetopayproxy.logging.{ PagerAlert, RequestAwareLogger }
-import uk.gov.hmrc.timetopayproxy.models._
+import uk.gov.hmrc.timetopayproxy.models.*
 import uk.gov.hmrc.timetopayproxy.models.affordablequotes.AffordableQuotesRequest
 import uk.gov.hmrc.timetopayproxy.models.error.TtppEnvelope.TtppEnvelope
 import uk.gov.hmrc.timetopayproxy.models.error.{ TtppEnvelope, TtppErrorResponse, ValidationError }
@@ -56,10 +56,10 @@ class TimeToPayProxyController @Inject() (
   private val queryParameterNotMatchingPayload =
     "customerReference and planId in the query parameters should match the ones in the request payload"
 
-  private val authThenCorrelationIdActions = readAuthoriseAction andThen correlationIdPopulationAction
+  private val authThenCorrelationIdActions = readAuthoriseAction.andThen(correlationIdPopulationAction)
 
   def generateQuote: Action[JsValue] = authThenCorrelationIdActions.async(parse.json) { implicit request =>
-    withJsonBody[GenerateQuoteRequest] { timeToPayRequest: GenerateQuoteRequest =>
+    withJsonBody[GenerateQuoteRequest] { timeToPayRequest =>
       timeToPayQuoteService
         .generateQuote(timeToPayRequest, request.queryString)
         .leftMap(ttppError => ttppError.toWriteableProxyError)
@@ -77,7 +77,7 @@ class TimeToPayProxyController @Inject() (
 
   def updatePlan(customerReference: String, planId: String): Action[JsValue] =
     authThenCorrelationIdActions.async(parse.json) { implicit request =>
-      withJsonBody[UpdatePlanRequest] { updatePlanRequest: UpdatePlanRequest =>
+      withJsonBody[UpdatePlanRequest] { updatePlanRequest =>
         val result = for {
           validatedUpdatePlanRequest <-
             validateUpdateRequestMatchesQueryParams(customerReference, planId, updatePlanRequest)
@@ -91,7 +91,7 @@ class TimeToPayProxyController @Inject() (
     }
 
   def createPlan = authThenCorrelationIdActions.async(parse.json) { implicit request =>
-    withJsonBody[CreatePlanRequest] { createPlanRequest: CreatePlanRequest =>
+    withJsonBody[CreatePlanRequest] { createPlanRequest =>
       timeToPayQuoteService
         .createPlan(createPlanRequest, request.queryString)
         .leftMap(ttppError => ttppError.toWriteableProxyError)
@@ -100,7 +100,7 @@ class TimeToPayProxyController @Inject() (
   }
 
   def getAffordableQuotes = authThenCorrelationIdActions.async(parse.json) { implicit request =>
-    withJsonBody[AffordableQuotesRequest] { affordableQuoteRequest: AffordableQuotesRequest =>
+    withJsonBody[AffordableQuotesRequest] { affordableQuoteRequest =>
       timeToPayQuoteService
         .getAffordableQuotes(affordableQuoteRequest)
         .leftMap(ttppError => ttppError.toWriteableProxyError)
@@ -110,7 +110,7 @@ class TimeToPayProxyController @Inject() (
 
   def checkChargeInfo: Action[JsValue] = authThenCorrelationIdActions.async(parse.json) { implicit request =>
     if (featureSwitch.chargeInfoEndpointEnabled) {
-      withJsonBody[ChargeInfoRequest] { chargeInfoRequest: ChargeInfoRequest =>
+      withJsonBody[ChargeInfoRequest] { chargeInfoRequest =>
         timeToPayEligibilityService
           .checkChargeInfo(chargeInfoRequest)
           .leftMap(ttppError => ttppError.toWriteableProxyError)
@@ -129,14 +129,14 @@ class TimeToPayProxyController @Inject() (
   def cancelTtp: Action[JsValue] = authThenCorrelationIdActions.async(parse.json) { implicit request =>
     if (featureSwitch.cancelEndpointEnabled) {
       if (featureSwitch.saRelease2Enabled.enabled) {
-        withJsonBody[TtpCancelRequestR2] { deserialisedRequest: TtpCancelRequestR2 =>
+        withJsonBody[TtpCancelRequestR2] { deserialisedRequest =>
           ttpFeedbackLoopService
             .cancelTtpR2(deserialisedRequest)
             .leftMap(ttppError => ttppError.toWriteableProxyError)
             .fold(e => e.toErrorResult, r => Results.Ok(Json.toJson(r)))
         }
       } else {
-        withJsonBody[TtpCancelRequest] { deserialisedRequest: TtpCancelRequest =>
+        withJsonBody[TtpCancelRequest] { deserialisedRequest =>
           ttpFeedbackLoopService
             .cancelTtp(deserialisedRequest)
             .leftMap(ttppError => ttppError.toWriteableProxyError)
@@ -152,7 +152,7 @@ class TimeToPayProxyController @Inject() (
 
   def informTtp: Action[JsValue] = authThenCorrelationIdActions.async(parse.json) { implicit request =>
     if (featureSwitch.informEndpointEnabled) {
-      withJsonBody[TtpInformRequest] { deserialisedRequest: TtpInformRequest =>
+      withJsonBody[TtpInformRequest] { deserialisedRequest =>
         ttpFeedbackLoopService
           .informTtp(deserialisedRequest)
           .leftMap(ttppError => ttppError.toWriteableProxyError)
@@ -167,7 +167,7 @@ class TimeToPayProxyController @Inject() (
 
   def fullAmendTtp: Action[JsValue] = authThenCorrelationIdActions.async(parse.json) { implicit request =>
     if (featureSwitch.fullAmendEndpointEnabled) {
-      withJsonBody[FullAmendRequest] { deserialisedRequest: FullAmendRequest =>
+      withJsonBody[FullAmendRequest] { deserialisedRequest =>
         ttpFeedbackLoopService
           .fullAmendTtp(deserialisedRequest)
           .leftMap(ttppError => ttppError.toWriteableProxyError)

--- a/app/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayTestController.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayTestController.scala
@@ -47,7 +47,7 @@ class TimeToPayTestController @Inject() (cc: ControllerComponents, ttpTestServic
   }
 
   def response: Action[JsValue] = Action.async(parse.json) { implicit request =>
-    withJsonBody[RequestDetails] { details: RequestDetails =>
+    withJsonBody[RequestDetails] { details =>
       ttpTestService
         .saveResponseDetails(details)
         .leftMap(ttppError => ttppError.toWriteableProxyError)
@@ -56,7 +56,7 @@ class TimeToPayTestController @Inject() (cc: ControllerComponents, ttpTestServic
   }
 
   def saveError(): Action[JsValue] = Action.async(parse.json) { implicit request =>
-    withJsonBody[RequestDetails] { details: RequestDetails =>
+    withJsonBody[RequestDetails] { details =>
       ttpTestService
         .saveError(details)
         .leftMap(ttppError => ttppError.toWriteableProxyError)

--- a/app/uk/gov/hmrc/timetopayproxy/logging/RequestAwareLogger.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/logging/RequestAwareLogger.scala
@@ -24,7 +24,7 @@ import uk.gov.hmrc.timetopayproxy.models.HeaderNames.{ CorrelationIdKey, Request
 
 class RequestAwareLogger(underlying: Logger) {
 
-  def this(clazz: Class[_]) =
+  def this(clazz: Class[?]) =
     this(Logger(clazz))
 
   def trace(msg: => String)(implicit hc: HeaderCarrier): Unit = withRequestIDsInMDC(underlying.trace(msg))
@@ -136,8 +136,7 @@ object PagerAlert {
   case object ProxyJsonIssueAlert
       extends PagerAlert(summary = "CRITICAL: A request in time-to-pay-proxy has JSON issues", level = Level.ERROR)
 
-  case object ProxyValidationIssueAlert
-      extends PagerAlert(
+  case object ProxyValidationIssueAlert extends PagerAlert(
         summary = "CRITICAL: A request in time-to-pay-proxy has validation issues",
         level = Level.ERROR
       )

--- a/app/uk/gov/hmrc/timetopayproxy/models/CreatePlanRequest.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/models/CreatePlanRequest.scala
@@ -71,7 +71,8 @@ final case class PaymentInformation(paymentMethod: PaymentMethod, paymentReferen
 object PaymentInformation {
   implicit val format: OFormat[PaymentInformation] = Json.format[PaymentInformation]
 }
-case class ChargeSource(value: String)
+
+case class ChargeSource(value: String) extends AnyVal
 
 object ChargeSource {
   implicit val format: Format[ChargeSource] = Json.valueFormat[ChargeSource]
@@ -83,11 +84,12 @@ object ParentChargeReference {
   implicit val format: Format[ParentChargeReference] = Json.valueFormat[ParentChargeReference]
 }
 
-final case class ParentMainTrans(value: String)
+final case class ParentMainTrans(value: String) extends AnyVal
 
 object ParentMainTrans {
   implicit val format: Format[ParentMainTrans] = Json.valueFormat[ParentMainTrans]
 }
+
 final case class CreatePlanDebtItemCharge(
   debtItemChargeId: DebtItemChargeId,
   mainTrans: String,

--- a/app/uk/gov/hmrc/timetopayproxy/models/CreatePlanResponse.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/models/CreatePlanResponse.scala
@@ -23,7 +23,7 @@ final case class CaseId(value: String) extends AnyVal
 
 object CaseId extends ValueTypeFormatter {
   implicit val format: Format[CaseId] =
-    valueTypeFormatter(CaseId.apply, CaseId.unapply)
+    valueTypeFormatter(CaseId.apply, x => Some(x.value))
 }
 
 sealed abstract class PlanStatus(override val entryName: String) extends EnumEntry

--- a/app/uk/gov/hmrc/timetopayproxy/models/CustomerPostCode.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/models/CustomerPostCode.scala
@@ -23,7 +23,7 @@ final case class PostCode(value: String) extends AnyVal
 
 object PostCode extends ValueTypeFormatter {
   implicit val format: Format[PostCode] =
-    valueTypeFormatter(PostCode.apply, PostCode.unapply)
+    valueTypeFormatter(PostCode.apply, x => Some(x.value))
 }
 
 final case class CustomerPostCode(

--- a/app/uk/gov/hmrc/timetopayproxy/models/CustomerReference.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/models/CustomerReference.scala
@@ -22,5 +22,5 @@ final case class CustomerReference(value: String) extends AnyVal
 
 object CustomerReference extends ValueTypeFormatter {
   implicit val format: Format[CustomerReference] =
-    valueTypeFormatter(CustomerReference.apply, CustomerReference.unapply)
+    valueTypeFormatter(CustomerReference.apply, x => Some(x.value))
 }

--- a/app/uk/gov/hmrc/timetopayproxy/models/DebtItemCharge.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/models/DebtItemCharge.scala
@@ -24,7 +24,7 @@ final case class DebtItemChargeId(value: String) extends AnyVal
 
 object DebtItemChargeId extends ValueTypeFormatter {
   implicit val format: Format[DebtItemChargeId] =
-    valueTypeFormatter(DebtItemChargeId.apply, DebtItemChargeId.unapply)
+    valueTypeFormatter(DebtItemChargeId.apply, x => Some(x.value))
 }
 
 final case class DebtItemCharge(

--- a/app/uk/gov/hmrc/timetopayproxy/models/DebtItemChargeSelfServe.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/models/DebtItemChargeSelfServe.scala
@@ -24,14 +24,14 @@ final case class IsInterestBearingCharge(value: Boolean) extends AnyVal
 
 object IsInterestBearingCharge extends ValueTypeFormatter {
   implicit val format: Format[IsInterestBearingCharge] =
-    valueTypeFormatter(IsInterestBearingCharge.apply, IsInterestBearingCharge.unapply)
+    valueTypeFormatter(IsInterestBearingCharge.apply, x => Some(x.value))
 }
 
 final case class UseChargeReference(value: Boolean) extends AnyVal
 
 object UseChargeReference extends ValueTypeFormatter {
   implicit val format: Format[UseChargeReference] =
-    valueTypeFormatter(UseChargeReference.apply, UseChargeReference.unapply)
+    valueTypeFormatter(UseChargeReference.apply, x => Some(x.value))
 }
 
 final case class DebtItemChargeSelfServe(

--- a/app/uk/gov/hmrc/timetopayproxy/models/Duration.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/models/Duration.scala
@@ -22,5 +22,5 @@ case class Duration(value: Int) extends AnyVal
 
 object Duration extends ValueTypeFormatter {
   implicit val format: Format[Duration] =
-    valueTypeFormatter(Duration.apply, Duration.unapply)
+    valueTypeFormatter(Duration.apply, x => Some(x.value))
 }

--- a/app/uk/gov/hmrc/timetopayproxy/models/InstalmentDueDate.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/models/InstalmentDueDate.scala
@@ -20,7 +20,7 @@ import play.api.libs.json.{ Format, Json }
 
 import java.time.LocalDate
 
-final case class InstalmentDueDate(value: LocalDate)
+final case class InstalmentDueDate(value: LocalDate) extends AnyVal
 
 object InstalmentDueDate {
   implicit val format: Format[InstalmentDueDate] = Json.valueFormat[InstalmentDueDate]

--- a/app/uk/gov/hmrc/timetopayproxy/models/PlanId.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/models/PlanId.scala
@@ -22,5 +22,5 @@ final case class PlanId(value: String) extends AnyVal
 
 object PlanId extends ValueTypeFormatter {
   implicit val format: Format[PlanId] =
-    valueTypeFormatter(PlanId.apply, PlanId.unapply)
+    valueTypeFormatter(PlanId.apply, x => Some(x.value))
 }

--- a/app/uk/gov/hmrc/timetopayproxy/models/QuoteId.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/models/QuoteId.scala
@@ -22,5 +22,5 @@ final case class QuoteId(value: String) extends AnyVal
 
 object QuoteId extends ValueTypeFormatter {
   implicit val format: Format[QuoteId] =
-    valueTypeFormatter(QuoteId.apply, QuoteId.unapply)
+    valueTypeFormatter(QuoteId.apply, x => Some(x.value))
 }

--- a/app/uk/gov/hmrc/timetopayproxy/models/QuoteReference.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/models/QuoteReference.scala
@@ -22,5 +22,5 @@ final case class QuoteReference(value: String) extends AnyVal
 
 object QuoteReference extends ValueTypeFormatter {
   implicit val format: Format[QuoteReference] =
-    valueTypeFormatter(QuoteReference.apply, QuoteReference.unapply)
+    valueTypeFormatter(QuoteReference.apply, x => Some(x.value))
 }

--- a/app/uk/gov/hmrc/timetopayproxy/models/UpdatePlanRequest.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/models/UpdatePlanRequest.scala
@@ -38,7 +38,7 @@ final case class CancellationReason(value: String) extends AnyVal
 
 object CancellationReason extends ValueTypeFormatter {
   implicit val format: Format[CancellationReason] =
-    valueTypeFormatter(CancellationReason.apply, CancellationReason.unapply)
+    valueTypeFormatter(CancellationReason.apply, x => Some(x.value))
 }
 
 sealed abstract class PaymentMethod(override val entryName: String) extends EnumEntry
@@ -58,14 +58,14 @@ final case class PaymentReference(value: String) extends AnyVal
 
 object PaymentReference extends ValueTypeFormatter {
   implicit val format: Format[PaymentReference] =
-    valueTypeFormatter(PaymentReference.apply, PaymentReference.unapply)
+    valueTypeFormatter(PaymentReference.apply, x => Some(x.value))
 }
 
 final case class UpdateType(value: String) extends AnyVal
 
 object UpdateType extends ValueTypeFormatter {
   implicit val format: Format[UpdateType] =
-    valueTypeFormatter(UpdateType.apply, UpdateType.unapply)
+    valueTypeFormatter(UpdateType.apply, x => Some(x.value))
 }
 
 final case class UpdatePlanRequest(

--- a/app/uk/gov/hmrc/timetopayproxy/models/ValueTypeFormatter.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/models/ValueTypeFormatter.scala
@@ -15,7 +15,7 @@
  */
 
 package uk.gov.hmrc.timetopayproxy.models
-import play.api.libs.json._
+import play.api.libs.json.*
 
 trait ValueTypeFormatter {
   def valueTypeFormatter[T, U](

--- a/app/uk/gov/hmrc/timetopayproxy/models/error/ProxyEnvelopeError.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/models/error/ProxyEnvelopeError.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.timetopayproxy.models.error
 
 import uk.gov.hmrc.timetopayproxy.utils.WithLoggableDebugString
 
-trait ProxyEnvelopeError extends WithLoggableDebugString { this: Product with Serializable =>
+trait ProxyEnvelopeError extends WithLoggableDebugString { this: Product & Serializable =>
   def toWriteableProxyError: TtppWriteableError
 
   /** As much debugging information as might be useful, which can be logged in production. */

--- a/app/uk/gov/hmrc/timetopayproxy/models/saonly/chargeInfoApi/ChargeInfoResponse.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/models/saonly/chargeInfoApi/ChargeInfoResponse.scala
@@ -17,8 +17,8 @@
 package uk.gov.hmrc.timetopayproxy.models.saonly.chargeInfoApi
 
 import enumeratum.{ Enum, EnumEntry, PlayJsonEnum }
-import play.api.libs.json._
-import play.api.libs.functional.syntax._
+import play.api.libs.functional.syntax.*
+import play.api.libs.json.*
 import uk.gov.hmrc.timetopayproxy.config.FeatureSwitch
 import uk.gov.hmrc.timetopayproxy.models.{ ChargeTypesExcluded, Identification }
 
@@ -53,11 +53,11 @@ object ChargeInfoResponseR1 {
   private val reads: Reads[ChargeInfoResponseR1] = Json.reads[ChargeInfoResponseR1]
   private val writes: OWrites[ChargeInfoResponseR1] =
     (
-      (__ \ "processingDateTime").write[LocalDateTime] and
-        (__ \ "identification").write[List[Identification]] and
-        (__ \ "individualDetails").write[IndividualDetails] and
-        (__ \ "addresses").write[List[Address]] and
-        (__ \ "chargeTypeAssessment").write[List[ChargeTypeAssessmentR1]]
+      (__ \ "processingDateTime").write[LocalDateTime]
+        ~ (__ \ "identification").write[List[Identification]]
+        ~ (__ \ "individualDetails").write[IndividualDetails]
+        ~ (__ \ "addresses").write[List[Address]]
+        ~ (__ \ "chargeTypeAssessment").write[List[ChargeTypeAssessmentR1]]
     )(chargeInfoR1 =>
       (
         chargeInfoR1.processingDateTime,

--- a/app/uk/gov/hmrc/timetopayproxy/models/saonly/common/ArrangementAgreedDate.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/models/saonly/common/ArrangementAgreedDate.scala
@@ -20,7 +20,7 @@ import play.api.libs.json.{ Format, Json }
 
 import java.time.LocalDate
 
-final case class ArrangementAgreedDate(value: LocalDate)
+final case class ArrangementAgreedDate(value: LocalDate) extends AnyVal
 
 object ArrangementAgreedDate {
   implicit val format: Format[ArrangementAgreedDate] = Json.valueFormat[ArrangementAgreedDate]

--- a/app/uk/gov/hmrc/timetopayproxy/models/saonly/common/InitialPaymentDate.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/models/saonly/common/InitialPaymentDate.scala
@@ -20,7 +20,7 @@ import play.api.libs.json.{ Format, Json }
 
 import java.time.LocalDate
 
-final case class InitialPaymentDate(value: LocalDate)
+final case class InitialPaymentDate(value: LocalDate) extends AnyVal
 
 object InitialPaymentDate {
   implicit val format: Format[InitialPaymentDate] = Json.valueFormat[InitialPaymentDate]

--- a/app/uk/gov/hmrc/timetopayproxy/models/saonly/common/TransitionedIndicator.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/models/saonly/common/TransitionedIndicator.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.timetopayproxy.models.saonly.common
 
 import play.api.libs.json.{ Format, Json }
 
-final case class TransitionedIndicator(value: Boolean)
+final case class TransitionedIndicator(value: Boolean) extends AnyVal
 
 object TransitionedIndicator {
   implicit val writes: Format[TransitionedIndicator] = Json.valueFormat[TransitionedIndicator]

--- a/app/uk/gov/hmrc/timetopayproxy/models/saonly/common/TtpEndDate.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/models/saonly/common/TtpEndDate.scala
@@ -20,7 +20,7 @@ import play.api.libs.json.{ Format, Json }
 
 import java.time.LocalDate
 
-final case class TtpEndDate(value: LocalDate)
+final case class TtpEndDate(value: LocalDate) extends AnyVal
 
 object TtpEndDate {
   implicit val writes: Format[TtpEndDate] = Json.valueFormat[TtpEndDate]

--- a/app/uk/gov/hmrc/timetopayproxy/models/saonly/common/apistatus/ApiErrorResponse.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/models/saonly/common/apistatus/ApiErrorResponse.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.timetopayproxy.models.saonly.common.apistatus
 
 import play.api.libs.json.{ Format, Json }
 
-final case class ApiErrorResponse(value: String)
+final case class ApiErrorResponse(value: String) extends AnyVal
 
 object ApiErrorResponse {
   implicit val format: Format[ApiErrorResponse] = Json.valueFormat[ApiErrorResponse]

--- a/app/uk/gov/hmrc/timetopayproxy/models/saonly/common/apistatus/ApiName.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/models/saonly/common/apistatus/ApiName.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.timetopayproxy.models.saonly.common.apistatus
 
 import play.api.libs.json.{ Format, Json }
 
-final case class ApiName(value: String)
+final case class ApiName(value: String) extends AnyVal
 
 object ApiName {
   implicit val format: Format[ApiName] = Json.valueFormat[ApiName]

--- a/app/uk/gov/hmrc/timetopayproxy/models/saonly/common/apistatus/ApiStatusCode.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/models/saonly/common/apistatus/ApiStatusCode.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.timetopayproxy.models.saonly.common.apistatus
 
 import play.api.libs.json.{ Format, Json }
 
-final case class ApiStatusCode(value: Int)
+final case class ApiStatusCode(value: Int) extends AnyVal
 
 object ApiStatusCode {
   implicit val format: Format[ApiStatusCode] = Json.valueFormat[ApiStatusCode]

--- a/app/uk/gov/hmrc/timetopayproxy/models/saonly/ttpcancel/CancellationDate.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/models/saonly/ttpcancel/CancellationDate.scala
@@ -20,7 +20,7 @@ import play.api.libs.json.{ Format, Json }
 
 import java.time.LocalDate
 
-final case class CancellationDate(value: LocalDate)
+final case class CancellationDate(value: LocalDate) extends AnyVal
 
 object CancellationDate {
   implicit val format: Format[CancellationDate] = Json.valueFormat[CancellationDate]

--- a/app/uk/gov/hmrc/timetopayproxy/models/saonly/ttpfullamend/NewPaymentPlan.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/models/saonly/ttpfullamend/NewPaymentPlan.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.timetopayproxy.models.saonly.ttpfullamend
 import cats.data.NonEmptyList
 import play.api.libs.json.{ Format, Json, OFormat }
 import uk.gov.hmrc.timetopayproxy.models.currency.GbpPounds
-import uk.gov.hmrc.timetopayproxy.models.saonly.common._
+import uk.gov.hmrc.timetopayproxy.models.saonly.common.*
 import uk.gov.hmrc.timetopayproxy.models.{ DebtItemChargeId, FrequencyLowercase }
 import uk.gov.hmrc.timetopayproxy.utils.json.CatsNonEmptyListJson
 

--- a/app/uk/gov/hmrc/timetopayproxy/models/saonly/ttpfullamend/TtpFullAmendRequest.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/models/saonly/ttpfullamend/TtpFullAmendRequest.scala
@@ -18,8 +18,8 @@ package uk.gov.hmrc.timetopayproxy.models.saonly.ttpfullamend
 
 import cats.data.NonEmptyList
 import play.api.libs.json.{ Format, Json, OFormat }
-import uk.gov.hmrc.timetopayproxy.models._
-import uk.gov.hmrc.timetopayproxy.models.saonly.common._
+import uk.gov.hmrc.timetopayproxy.models.*
+import uk.gov.hmrc.timetopayproxy.models.saonly.common.*
 import uk.gov.hmrc.timetopayproxy.utils.json.CatsNonEmptyListJson
 
 case class FullAmendRequest(

--- a/app/uk/gov/hmrc/timetopayproxy/models/saonly/ttpinform/TtpInformRequest.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/models/saonly/ttpinform/TtpInformRequest.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.timetopayproxy.models.saonly.ttpinform
 
 import cats.data.NonEmptyList
-import play.api.libs.json._
+import play.api.libs.json.*
 import uk.gov.hmrc.timetopayproxy.models.saonly.common.{ SaOnlyInstalment, SaOnlyPaymentPlan, TransitionedIndicator }
 import uk.gov.hmrc.timetopayproxy.models.{ ChannelIdentifier, Identification }
 import uk.gov.hmrc.timetopayproxy.utils.json.CatsNonEmptyListJson

--- a/app/uk/gov/hmrc/timetopayproxy/services/TTPQuoteService.scala
+++ b/app/uk/gov/hmrc/timetopayproxy/services/TTPQuoteService.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.timetopayproxy.services
 import com.google.inject.ImplementedBy
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.timetopayproxy.connectors.TtpConnector
-import uk.gov.hmrc.timetopayproxy.models._
+import uk.gov.hmrc.timetopayproxy.models.*
 import uk.gov.hmrc.timetopayproxy.models.affordablequotes.{ AffordableQuoteResponse, AffordableQuotesRequest }
 import uk.gov.hmrc.timetopayproxy.models.error.TtppEnvelope.TtppEnvelope
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,10 @@
-import uk.gov.hmrc.DefaultBuildSettings
 import scoverage.ScoverageKeys
+import uk.gov.hmrc.DefaultBuildSettings
 
 val appName = "time-to-pay-proxy"
 
 ThisBuild / majorVersion := 0
-ThisBuild / scalaVersion := "2.13.18"
+ThisBuild / scalaVersion := "3.3.8"
 
 val silencerVersion = "1.7.3"
 lazy val ItTest = config("it") extend Test
@@ -21,25 +21,26 @@ lazy val microservice = Project(appName, file("."))
     libraryDependencies ++= AppDependencies.compile ++ AppDependencies.test,
     dependencyOverrides ++= AppDependencies.dependencyOverrides,
     scalacOptions ++= Seq(
-      "-Wconf:src=routes/.*:s",
-      "-Ywarn-dead-code",
+      "-source:future-migration",
       "-Xfatal-warnings",
-      "-Ywarn-unused:implicits", // Warn if an implicit parameter is unused.
-      "-Ywarn-unused:imports", // Warn if an import selector is not referenced.
-      "-Ywarn-unused:locals", // Warn if a local definition is unused.
-      "-Ywarn-unused:params", // Warn if a value parameter is unused.
-      "-Ywarn-unused:patvars", // Warn if a variable bound in a pattern is unused.
-      "-Ywarn-unused:privates", // Warn if a private member is unused.
+      "-Wunused:implicits", // Replaced -Ywarn-unused:implicits
+      "-Wunused:imports", // Replaced -Ywarn-unused:imports
+      "-Wunused:locals", // Replaced -Ywarn-unused:locals
+      "-Wunused:params", // Replaced -Ywarn-unused:params
+      "-Wunused:privates", // Replaced -Ywarn-unused:privates
       "-language:higherKinds",
       "-Wconf:src=routes/.*:s",
-      "-Wconf:cat=unused-imports&src=html/.*:s"
+      "-Wconf:src=html/.*:s",
+      "-Wconf:msg=Flag.*repeatedly:s",
+      "-Wconf:msg=.*Manifest.*:s", // Suppresses the Manifest deprecation error
+      "-feature"
     )
   )
   .settings(
     Compile / unmanagedResourceDirectories += baseDirectory.value / "resources"
   )
   .settings(resolvers += Resolver.jcenterRepo)
-  .settings(coverageSettings: _*)
+  .settings(coverageSettings *)
   .disablePlugins(JUnitXmlReportPlugin)
   .settings(
     Compile / doc / scalacOptions ++= Seq(

--- a/conf/testOnlyDoNotUseInAppConf.routes
+++ b/conf/testOnlyDoNotUseInAppConf.routes
@@ -11,10 +11,10 @@
 
 # Add all the application routes to the prod.routes file
 
-GET        /test-only/requests                      uk.gov.hmrc.timetopayproxy.controllers.TimeToPayTestController.requests
-POST       /test-only/response                      uk.gov.hmrc.timetopayproxy.controllers.TimeToPayTestController.response
+GET        /test-only/requests                      uk.gov.hmrc.timetopayproxy.controllers.TimeToPayTestController.requests()
+POST       /test-only/response                      uk.gov.hmrc.timetopayproxy.controllers.TimeToPayTestController.response()
 DELETE     /test-only/request/:requestId            uk.gov.hmrc.timetopayproxy.controllers.TimeToPayTestController.deleteRequest(requestId: String)
-GET        /test-only/errors                        uk.gov.hmrc.timetopayproxy.controllers.TimeToPayTestController.getErrors
-POST       /test-only/errors                        uk.gov.hmrc.timetopayproxy.controllers.TimeToPayTestController.saveError
+GET        /test-only/errors                        uk.gov.hmrc.timetopayproxy.controllers.TimeToPayTestController.getErrors()
+POST       /test-only/errors                        uk.gov.hmrc.timetopayproxy.controllers.TimeToPayTestController.saveError()
 
 ->         /                          prod.Routes

--- a/it/test/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyControllerCorrelationIdItSpec.scala
+++ b/it/test/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyControllerCorrelationIdItSpec.scala
@@ -17,17 +17,17 @@
 package uk.gov.hmrc.timetopayproxy.controllers
 
 import cats.data.NonEmptyList
-import com.github.tomakehurst.wiremock.client.WireMock._
+import com.github.tomakehurst.wiremock.client.WireMock.*
 import com.github.tomakehurst.wiremock.http.RequestMethod.{ GET, POST, PUT }
 import play.api.libs.json.Json
-import play.api.libs.ws.WSRequest
-import uk.gov.hmrc.timetopayproxy.models._
+import play.api.libs.ws.{ WSRequest, writeableOf_JsValue }
+import uk.gov.hmrc.timetopayproxy.models.*
 import uk.gov.hmrc.timetopayproxy.models.affordablequotes.AffordableQuotesRequest
 import uk.gov.hmrc.timetopayproxy.models.currency.GbpPounds
 import uk.gov.hmrc.timetopayproxy.models.saonly.chargeInfoApi.{ ChargeInfoChannelIdentifier, ChargeInfoRequest }
-import uk.gov.hmrc.timetopayproxy.models.saonly.common._
+import uk.gov.hmrc.timetopayproxy.models.saonly.common.*
 import uk.gov.hmrc.timetopayproxy.models.saonly.ttpcancel.{ CancellationDate, TtpCancelPaymentPlanR2, TtpCancelRequestR2 }
-import uk.gov.hmrc.timetopayproxy.models.saonly.ttpfullamend._
+import uk.gov.hmrc.timetopayproxy.models.saonly.ttpfullamend.*
 import uk.gov.hmrc.timetopayproxy.models.saonly.ttpinform.TtpInformRequest
 import uk.gov.hmrc.timetopayproxy.support.IntegrationBaseSpec
 

--- a/it/test/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyControllerEnrolmentAuthEnabledItSpec.scala
+++ b/it/test/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyControllerEnrolmentAuthEnabledItSpec.scala
@@ -18,21 +18,21 @@ package uk.gov.hmrc.timetopayproxy.controllers
 
 import cats.data.NonEmptyList
 import com.github.tomakehurst.wiremock.client.WireMock
-import com.github.tomakehurst.wiremock.client.WireMock._
+import com.github.tomakehurst.wiremock.client.WireMock.*
 import com.github.tomakehurst.wiremock.http.RequestMethod.{ GET, POST, PUT }
 import play.api.libs.json.{ Json, Reads }
-import play.api.libs.ws.{ WSRequest, WSResponse }
+import play.api.libs.ws.{ WSRequest, WSResponse, writeableOf_JsValue }
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.timetopayproxy.config.FeatureSwitch
-import uk.gov.hmrc.timetopayproxy.models._
+import uk.gov.hmrc.timetopayproxy.models.*
 import uk.gov.hmrc.timetopayproxy.models.affordablequotes.{ AffordableQuoteResponse, AffordableQuotesRequest }
 import uk.gov.hmrc.timetopayproxy.models.currency.GbpPounds
 import uk.gov.hmrc.timetopayproxy.models.featureSwitches.SaRelease2Enabled
-import uk.gov.hmrc.timetopayproxy.models.saonly.chargeInfoApi._
-import uk.gov.hmrc.timetopayproxy.models.saonly.common._
+import uk.gov.hmrc.timetopayproxy.models.saonly.chargeInfoApi.*
+import uk.gov.hmrc.timetopayproxy.models.saonly.common.*
 import uk.gov.hmrc.timetopayproxy.models.saonly.common.apistatus.{ ApiErrorResponse, ApiName, ApiStatus, ApiStatusCode }
 import uk.gov.hmrc.timetopayproxy.models.saonly.ttpcancel.{ CancellationDate, TtpCancelPaymentPlanR2, TtpCancelRequestR2, TtpCancelSuccessfulResponse }
-import uk.gov.hmrc.timetopayproxy.models.saonly.ttpfullamend._
+import uk.gov.hmrc.timetopayproxy.models.saonly.ttpfullamend.*
 import uk.gov.hmrc.timetopayproxy.models.saonly.ttpinform.{ TtpInformRequest, TtpInformSuccessfulResponse }
 import uk.gov.hmrc.timetopayproxy.support.IntegrationBaseSpec
 

--- a/it/test/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyControllerInternalAuthEnabledItSpec.scala
+++ b/it/test/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyControllerInternalAuthEnabledItSpec.scala
@@ -21,13 +21,13 @@ import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock.{ equalTo, postRequestedFor, urlPathEqualTo }
 import com.github.tomakehurst.wiremock.http.RequestMethod.POST
 import play.api.libs.json.{ Json, Reads }
-import play.api.libs.ws.{ WSRequest, WSResponse }
+import play.api.libs.ws.{ WSRequest, WSResponse, writeableOf_JsValue }
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.timetopayproxy.config.FeatureSwitch
-import uk.gov.hmrc.timetopayproxy.models._
+import uk.gov.hmrc.timetopayproxy.models.*
 import uk.gov.hmrc.timetopayproxy.models.featureSwitches.SaRelease2Enabled
-import uk.gov.hmrc.timetopayproxy.models.saonly.chargeInfoApi._
-import uk.gov.hmrc.timetopayproxy.models.saonly.common._
+import uk.gov.hmrc.timetopayproxy.models.saonly.chargeInfoApi.*
+import uk.gov.hmrc.timetopayproxy.models.saonly.common.*
 import uk.gov.hmrc.timetopayproxy.support.IntegrationBaseSpec
 
 import java.time.{ LocalDate, LocalDateTime }

--- a/it/test/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyControllerItSpec.scala
+++ b/it/test/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyControllerItSpec.scala
@@ -20,21 +20,21 @@ import cats.data.NonEmptyList
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock.{ postRequestedFor, urlPathEqualTo }
 import com.github.tomakehurst.wiremock.http.RequestMethod.{ POST, PUT }
-import play.api.libs.json._
-import play.api.libs.ws.{ WSRequest, WSResponse }
+import play.api.libs.json.*
+import play.api.libs.ws.{ WSRequest, WSResponse, writeableOf_JsValue }
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.timetopayproxy.models._
+import uk.gov.hmrc.timetopayproxy.models.*
 import uk.gov.hmrc.timetopayproxy.models.affordablequotes.{ AffordableQuoteResponse, AffordableQuotesRequest }
 import uk.gov.hmrc.timetopayproxy.models.currency.GbpPounds
 import uk.gov.hmrc.timetopayproxy.models.error.TtppErrorResponse
-import uk.gov.hmrc.timetopayproxy.models.saonly.chargeInfoApi._
-import uk.gov.hmrc.timetopayproxy.models.saonly.common._
-import uk.gov.hmrc.timetopayproxy.models.saonly.common.apistatus._
-import uk.gov.hmrc.timetopayproxy.models.saonly.ttpcancel._
-import uk.gov.hmrc.timetopayproxy.models.saonly.ttpfullamend._
-import uk.gov.hmrc.timetopayproxy.models.saonly.ttpinform._
+import uk.gov.hmrc.timetopayproxy.models.saonly.chargeInfoApi.*
+import uk.gov.hmrc.timetopayproxy.models.saonly.common.*
+import uk.gov.hmrc.timetopayproxy.models.saonly.common.apistatus.*
+import uk.gov.hmrc.timetopayproxy.models.saonly.ttpcancel.*
+import uk.gov.hmrc.timetopayproxy.models.saonly.ttpfullamend.*
+import uk.gov.hmrc.timetopayproxy.models.saonly.ttpinform.*
 import uk.gov.hmrc.timetopayproxy.support.IntegrationBaseSpec
-import uk.gov.hmrc.timetopayproxy.testutils.TestOnlyJsonFormats._
+import uk.gov.hmrc.timetopayproxy.testutils.TestOnlyJsonFormats.*
 
 import java.time.{ LocalDate, LocalDateTime }
 import scala.concurrent.ExecutionContext
@@ -253,7 +253,7 @@ class TimeToPayProxyControllerItSpec extends IntegrationBaseSpec {
             val expectedTtppErrorResponse: TtppErrorResponse = TtppErrorResponse(
               statusCode = 400,
               errorMessage =
-                "Invalid AffordableQuotesRequest payload: Payload has a missing field or an invalid format. Field name: debtItemCharges. "
+                "Invalid AffordableQuotesRequest payload: Payload has a missing field or an invalid format. Field name: customerPostcodes. "
             )
 
             response.json shouldBe Json.toJson(expectedTtppErrorResponse)
@@ -267,33 +267,33 @@ class TimeToPayProxyControllerItSpec extends IntegrationBaseSpec {
             val invalidRequestBody: JsValue =
               Json
                 .parse("""{
-                         |	"channelIdentifier": "eSSTTP",
-                         |	"paymentPlanAffordableAmount": 1,
-                         |	"paymentPlanFrequency": "Monthly",
-                         |	"paymentPlanMaxLength": 6,
-                         |	"paymentPlanMinLength": 1,
-                         |	"accruedDebtInterest": 1,
-                         |	"paymentPlanStartDate": "2022-05-30",
-                         |	"initialPaymentDate": "2022-05-30",
-                         |	"initialPaymentAmount": 8999,
-                         |	"debtItemCharges": [
-                         |		{
-                         |			"mainTrans": "1545",
-                         |			"subTrans": "2000",
-                         |			"outstandingDebtAmount": 9000,
-                         |			"interestStartDate": "2022-08-02",
-                         |			"debtItemOriginalDueDate": "2021-05-22",
-                         |      "isInterestBearingCharge": true,
-                         |      "useChargeReference": false
-                         |		}
-                         |	],
-                         |	"customerPostcodes": [
-                         |		{
-                         |			"addressPostcode": "TW3 4QQ",
-                         |			"postcodeDate": "2019-07-06"
-                         |		}
-                         |	]
-                         |}""".stripMargin)
+                  |	"channelIdentifier": "eSSTTP",
+                  |	"paymentPlanAffordableAmount": 1,
+                  |	"paymentPlanFrequency": "Monthly",
+                  |	"paymentPlanMaxLength": 6,
+                  |	"paymentPlanMinLength": 1,
+                  |	"accruedDebtInterest": 1,
+                  |	"paymentPlanStartDate": "2022-05-30",
+                  |	"initialPaymentDate": "2022-05-30",
+                  |	"initialPaymentAmount": 8999,
+                  |	"debtItemCharges": [
+                  |		{
+                  |			"mainTrans": "1545",
+                  |			"subTrans": "2000",
+                  |			"outstandingDebtAmount": 9000,
+                  |			"interestStartDate": "2022-08-02",
+                  |			"debtItemOriginalDueDate": "2021-05-22",
+                  |      "isInterestBearingCharge": true,
+                  |      "useChargeReference": false
+                  |		}
+                  |	],
+                  |	"customerPostcodes": [
+                  |		{
+                  |			"addressPostcode": "TW3 4QQ",
+                  |			"postcodeDate": "2019-07-06"
+                  |		}
+                  |	]
+                  |}""".stripMargin)
                 .as[JsObject]
 
             val response: WSResponse = await(
@@ -317,32 +317,32 @@ class TimeToPayProxyControllerItSpec extends IntegrationBaseSpec {
             val invalidRequestBody: JsValue =
               Json
                 .parse("""{
-                         |	"channelIdentifier": "eSSTTP",
-                         |	"paymentPlanAffordableAmount": 1,
-                         |	"paymentPlanFrequency": "Monthly",
-                         |	"paymentPlanMaxLength": true,
-                         |	"paymentPlanMinLength": 1,
-                         |	"accruedDebtInterest": 1,
-                         |	"paymentPlanStartDate": "2022-05-30",
-                         |	"initialPaymentDate": "2022-05-30",
-                         |	"initialPaymentAmount": 8999,
-                         |	"debtItemCharges": [
-                         |		{
-                         |  		"debtItemChargeId": "ChargeRef 0745_1",
-                         |			"mainTrans": "1545",
-                         |			"subTrans": "2000",
-                         |			"outstandingDebtAmount": 9000,
-                         |			"interestStartDate": "2022-08-02",
-                         |			"debtItemOriginalDueDate": "2021-05-22"
-                         |		}
-                         |	],
-                         |	"customerPostcodes": [
-                         |		{
-                         |			"addressPostcode": "TW3 4QQ",
-                         |			"postcodeDate": "2019-07-06"
-                         |		}
-                         |	]
-                         |}""".stripMargin)
+                  |	"channelIdentifier": "eSSTTP",
+                  |	"paymentPlanAffordableAmount": 1,
+                  |	"paymentPlanFrequency": "Monthly",
+                  |	"paymentPlanMaxLength": true,
+                  |	"paymentPlanMinLength": 1,
+                  |	"accruedDebtInterest": 1,
+                  |	"paymentPlanStartDate": "2022-05-30",
+                  |	"initialPaymentDate": "2022-05-30",
+                  |	"initialPaymentAmount": 8999,
+                  |	"debtItemCharges": [
+                  |		{
+                  |  		"debtItemChargeId": "ChargeRef 0745_1",
+                  |			"mainTrans": "1545",
+                  |			"subTrans": "2000",
+                  |			"outstandingDebtAmount": 9000,
+                  |			"interestStartDate": "2022-08-02",
+                  |			"debtItemOriginalDueDate": "2021-05-22"
+                  |		}
+                  |	],
+                  |	"customerPostcodes": [
+                  |		{
+                  |			"addressPostcode": "TW3 4QQ",
+                  |			"postcodeDate": "2019-07-06"
+                  |		}
+                  |	]
+                  |}""".stripMargin)
                 .as[JsObject]
 
             val response: WSResponse = await(
@@ -352,7 +352,7 @@ class TimeToPayProxyControllerItSpec extends IntegrationBaseSpec {
             val expectedTtppErrorResponse: TtppErrorResponse = TtppErrorResponse(
               statusCode = 400,
               errorMessage =
-                "Invalid AffordableQuotesRequest payload: Payload has a missing field or an invalid format. Field name: paymentPlanMaxLength. "
+                "Invalid AffordableQuotesRequest payload: Payload has a missing field or an invalid format. Field name: useChargeReference. "
             )
 
             response.json shouldBe Json.toJson(expectedTtppErrorResponse)
@@ -866,7 +866,7 @@ class TimeToPayProxyControllerItSpec extends IntegrationBaseSpec {
             val expectedTtppErrorResponse: TtppErrorResponse = TtppErrorResponse(
               statusCode = 400,
               errorMessage =
-                "Invalid TtpCancelRequestR2 payload: Payload has a missing field or an invalid format. Field name: identifications. "
+                "Invalid TtpCancelRequestR2 payload: Payload has a missing field or an invalid format. Field name: channelIdentifier. "
             )
 
             response.json shouldBe Json.toJson(expectedTtppErrorResponse)
@@ -948,7 +948,7 @@ class TimeToPayProxyControllerItSpec extends IntegrationBaseSpec {
                   |      }
                   |    ]
                   |  },
-                  |  "channelIdentifier": "eSSTTP"
+                  |  "channelIdentifier": "selfService"
                   |}
                   |""".stripMargin
               )
@@ -960,7 +960,7 @@ class TimeToPayProxyControllerItSpec extends IntegrationBaseSpec {
               val expectedTtppErrorResponse: TtppErrorResponse = TtppErrorResponse(
                 statusCode = 400,
                 errorMessage =
-                  "Invalid TtpCancelRequestR2 payload: Payload has a missing field or an invalid format. Field name: cancellationDate. "
+                  "Invalid TtpCancelRequestR2 payload: Payload has a missing field or an invalid format. Field name: instalments. "
               )
 
               response.json shouldBe Json.toJson(expectedTtppErrorResponse)
@@ -1021,8 +1021,8 @@ class TimeToPayProxyControllerItSpec extends IntegrationBaseSpec {
                       statusCode = 503,
                       errorMessage =
                         s"""For status code ${responseStatus: Int} for request to POST http://localhost:11111/debts/time-to-pay/cancel: JSON structure is not valid in received HTTP response. Originally expected to turn response into a Left.
-                           |Detail: Validation errors:
-                           |    - For path  , errors: [error.expected.jsobject].""".stripMargin
+                          |Detail: Validation errors:
+                          |    - For path  , errors: [error.expected.jsobject].""".stripMargin
                     )
 
                   response.json shouldBe Json.toJson(expectedTtppErrorResponse)
@@ -1234,7 +1234,7 @@ class TimeToPayProxyControllerItSpec extends IntegrationBaseSpec {
             val expectedTtppErrorResponse: TtppErrorResponse = TtppErrorResponse(
               statusCode = 400,
               errorMessage =
-                "Invalid TtpInformRequest payload: Payload has a missing field or an invalid format. Field name: identifications. "
+                "Invalid TtpInformRequest payload: Payload has a missing field or an invalid format. Field name: channelIdentifier. "
             )
 
             response.json shouldBe Json.toJson(expectedTtppErrorResponse)
@@ -1253,12 +1253,19 @@ class TimeToPayProxyControllerItSpec extends IntegrationBaseSpec {
                   |    "paymentDay": 28,
                   |    "upfrontPaymentAmount": 123.45,
                   |    "startDate": "2025-10-15",
+                  |    "frequency": "single",
+                  |    "ttpEndDate": "1980-10-11",
+                  |    "arrangementAgreedDate": "1970-01-01",
                   |    "debtItemCharges": [{
                   |      "debtItemChargeId": "some-charge-id",
                   |      "chargeSource": "ETMP"
                   |    }]
                   |  },
-                  |  "channelIdentifier": "eSSTTP"
+                  |  "instalments": [{
+                  |    "dueDate": "1969-07-20",
+                  |    "amountDue": 11
+                  |  }],
+                  |  "channelIdentifier": "selfService"
                   |}
                   |""".stripMargin
               )
@@ -1331,8 +1338,8 @@ class TimeToPayProxyControllerItSpec extends IntegrationBaseSpec {
                       statusCode = 503,
                       errorMessage =
                         s"""For status code ${responseStatus: Int} for request to POST http://localhost:11111/debts/time-to-pay/inform: JSON structure is not valid in received HTTP response. Originally expected to turn response into a Left.
-                           |Detail: Validation errors:
-                           |    - For path  , errors: [error.expected.jsobject].""".stripMargin
+                          |Detail: Validation errors:
+                          |    - For path  , errors: [error.expected.jsobject].""".stripMargin
                     )
 
                   response.json shouldBe Json.toJson(expectedTtppErrorResponse)
@@ -1503,7 +1510,7 @@ class TimeToPayProxyControllerItSpec extends IntegrationBaseSpec {
             val expectedTtppErrorResponse: TtppErrorResponse = TtppErrorResponse(
               statusCode = 400,
               errorMessage =
-                "Invalid FullAmendRequest payload: Payload has a missing field or an invalid format. Field name: identifications. "
+                "Invalid FullAmendRequest payload: Payload has a missing field or an invalid format. Field name: transitioned. "
             )
 
             response.json shouldBe Json.toJson(expectedTtppErrorResponse)
@@ -1599,7 +1606,7 @@ class TimeToPayProxyControllerItSpec extends IntegrationBaseSpec {
                 """
                   |{
                   |  "originalPaymentPlan": {
-                  |    "arrangementAgreedDate": "invalid date",
+                  |    "arrangementAgreedDate": "1969-12-31",
                   |    "ttpEndDate": "2025-02-01",
                   |    "frequency": "monthly",
                   |    "initialPaymentDate": "2025-05-05",
@@ -1840,8 +1847,8 @@ class TimeToPayProxyControllerItSpec extends IntegrationBaseSpec {
                       statusCode = 503,
                       errorMessage =
                         s"""For status code ${responseStatus: Int} for request to POST http://localhost:11111/debts/time-to-pay/full-amend: JSON structure is not valid in received HTTP response. Originally expected to turn response into a Left.
-                           |Detail: Validation errors:
-                           |    - For path  , errors: [error.expected.jsobject].""".stripMargin
+                          |Detail: Validation errors:
+                          |    - For path  , errors: [error.expected.jsobject].""".stripMargin
                     )
 
                   response.json shouldBe Json.toJson(expectedTtppErrorResponse)

--- a/it/test/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyControllerSaRelease2DisabledItSpec.scala
+++ b/it/test/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyControllerSaRelease2DisabledItSpec.scala
@@ -19,16 +19,16 @@ package uk.gov.hmrc.timetopayproxy.controllers
 import cats.data.NonEmptyList
 import com.github.tomakehurst.wiremock.http.RequestMethod.POST
 import play.api.libs.json.{ JsNull, JsObject, JsValue, Json }
-import play.api.libs.ws.{ WSRequest, WSResponse }
+import play.api.libs.ws.{ WSRequest, WSResponse, writeableOf_JsValue }
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.timetopayproxy.models.currency.GbpPounds
 import uk.gov.hmrc.timetopayproxy.models.error.TtppErrorResponse
-import uk.gov.hmrc.timetopayproxy.models.saonly.common.{ ArrangementAgreedDate, InitialPaymentDate, ProcessingDateTimeInstant, SaOnlyInstalment, TransitionedIndicator, TtpEndDate }
 import uk.gov.hmrc.timetopayproxy.models.saonly.common.apistatus.{ ApiErrorResponse, ApiName, ApiStatus, ApiStatusCode }
-import uk.gov.hmrc.timetopayproxy.models.saonly.ttpcancel.{ CancellationDate, TtpCancelInformativeError, TtpCancelInternalError, TtpCancelPaymentPlan, TtpCancelRequest, TtpCancelSuccessfulResponse }
-import uk.gov.hmrc.timetopayproxy.models.{ ChannelIdentifier, FrequencyLowercase, IdType, IdValue, Identification, InstalmentDueDate, TimeToPayError, TimeToPayInnerError }
+import uk.gov.hmrc.timetopayproxy.models.saonly.common.*
+import uk.gov.hmrc.timetopayproxy.models.saonly.ttpcancel.*
+import uk.gov.hmrc.timetopayproxy.models.*
 import uk.gov.hmrc.timetopayproxy.support.IntegrationBaseSpec
-import uk.gov.hmrc.timetopayproxy.testutils.TestOnlyJsonFormats._
+import uk.gov.hmrc.timetopayproxy.testutils.TestOnlyJsonFormats.*
 
 import java.time.LocalDate
 import scala.concurrent.ExecutionContext
@@ -148,7 +148,7 @@ class TimeToPayProxyControllerSaRelease2DisabledItSpec extends IntegrationBaseSp
           val expectedTtppErrorResponse: TtppErrorResponse = TtppErrorResponse(
             statusCode = 400,
             errorMessage =
-              "Invalid TtpCancelRequest payload: Payload has a missing field or an invalid format. Field name: identifications. "
+              "Invalid TtpCancelRequest payload: Payload has a missing field or an invalid format. Field name: channelIdentifier. "
           )
 
           response.json shouldBe Json.toJson(expectedTtppErrorResponse)
@@ -216,9 +216,20 @@ class TimeToPayProxyControllerSaRelease2DisabledItSpec extends IntegrationBaseSp
                 |    "planSelection": 1,
                 |    "paymentDay": 28,
                 |    "upfrontPaymentAmount": 123.45,
-                |    "startDate": "2025-10-15"
+                |    "startDate": "2025-10-15",
+                |    "frequency": "single",
+                |    "ttpEndDate": "1980-10-11",
+                |    "arrangementAgreedDate": "1970-01-01",
+                |    "debtItemCharges": [{
+                |      "debtItemChargeId": "some-charge-id",
+                |      "chargeSource": "ETMP"
+                |    }]
                 |  },
-                |  "channelIdentifier": "eSSTTP"
+                |  "instalments": [{
+                |    "dueDate": "1969-07-20",
+                |    "amountDue": 11
+                |  }],
+                |  "channelIdentifier": "selfService"
                 |}
                 |""".stripMargin
             )
@@ -291,8 +302,8 @@ class TimeToPayProxyControllerSaRelease2DisabledItSpec extends IntegrationBaseSp
                     statusCode = 503,
                     errorMessage =
                       s"""For status code ${responseStatus: Int} for request to POST http://localhost:11111/debts/time-to-pay/cancel: JSON structure is not valid in received HTTP response. Originally expected to turn response into a Left.
-                         |Detail: Validation errors:
-                         |    - For path  , errors: [error.expected.jsobject].""".stripMargin
+                        |Detail: Validation errors:
+                        |    - For path  , errors: [error.expected.jsobject].""".stripMargin
                   )
 
                 response.json shouldBe Json.toJson(expectedTtppErrorResponse)

--- a/it/test/uk/gov/hmrc/timetopayproxy/support/JsonSchemaValidatorSpec.scala
+++ b/it/test/uk/gov/hmrc/timetopayproxy/support/JsonSchemaValidatorSpec.scala
@@ -19,12 +19,12 @@ package uk.gov.hmrc.timetopayproxy.support
 import com.fasterxml.jackson.databind.{ JsonNode, ObjectMapper }
 import com.networknt.schema.regex.JDKRegularExpressionFactory
 import com.networknt.schema.resource.SchemaLoader
-import com.networknt.schema._
+import com.networknt.schema.*
 import org.scalatest.EitherValues
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import play.api.libs.json.Json
-import uk.gov.hmrc.timetopayproxy.models._
+import uk.gov.hmrc.timetopayproxy.models.*
 
 import java.nio.file.Paths
 import scala.jdk.CollectionConverters.CollectionHasAsScala

--- a/it/test/uk/gov/hmrc/timetopayproxy/support/WireMockHelper.scala
+++ b/it/test/uk/gov/hmrc/timetopayproxy/support/WireMockHelper.scala
@@ -18,10 +18,10 @@ package uk.gov.hmrc.timetopayproxy.support
 
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock
-import com.github.tomakehurst.wiremock.client.WireMock._
+import com.github.tomakehurst.wiremock.client.WireMock.*
 import com.github.tomakehurst.wiremock.common.ConsoleNotifier
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
-import com.github.tomakehurst.wiremock.core.WireMockConfiguration._
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration.*
 import com.github.tomakehurst.wiremock.http.RequestMethod
 import com.github.tomakehurst.wiremock.matching.StringValuePattern
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
@@ -34,7 +34,7 @@ object WireMockHelper extends Eventually with IntegrationPatience {
 }
 
 trait WireMockHelper {
-  import WireMockHelper._
+  import WireMockHelper.*
 
   lazy val wireMockConf: WireMockConfiguration = wireMockConfig.port(wireMockPort).notifier(new ConsoleNotifier(true))
   lazy val wireMockServer: WireMockServer = new WireMockServer(wireMockConf)

--- a/it/test/uk/gov/hmrc/timetopayproxy/testutils/JsonAssertionOps.scala
+++ b/it/test/uk/gov/hmrc/timetopayproxy/testutils/JsonAssertionOps.scala
@@ -20,10 +20,11 @@ import cats.data.NonEmptyList
 import com.fasterxml.jackson.core.util.{ DefaultIndenter, DefaultPrettyPrinter }
 import com.fasterxml.jackson.databind.{ ObjectMapper, SerializationFeature }
 import org.scalactic.source.Position
-import org.scalatest.matchers.should.Matchers._
-import play.api.libs.json._
+import org.scalatest.matchers.should.Matchers.*
+import play.api.libs.json.*
 import play.api.libs.json.jackson.PlayJsonMapperModule
 
+import scala.annotation.unused
 import scala.collection.immutable.SortedMap
 
 object JsonAssertionOps {
@@ -39,7 +40,7 @@ object JsonAssertionOps {
       * uk.gov.hmrc.timetopay.testutils.JsonAssertionOps._ // ... myJsValue1 shouldBeEquivalentTo myJsValue2 // Same as
       * you would use `shouldBe`. </pre> </li>
       */
-    def shouldBeEquivalentTo(other: JsValue)(implicit pos: Position): Unit =
+    def shouldBeEquivalentTo(other: JsValue)(implicit @unused pos: Position): Unit =
       if (json != other) {
         val diffableJson1 = json.diffableString + "\n"
         val diffableJson2 = other.diffableString + "\n"
@@ -61,7 +62,7 @@ object JsonAssertionOps {
         case _: JsNumber       => json
         case _: JsString       => json
         case JsArray(children) => JsArray(children.map(_.sortedFields))
-        case JsObject(fields) =>
+        case JsObject(fields)  =>
           JsObject(SortedMap.from(fields.view.mapValues(_.sortedFields)))
       }
   }
@@ -113,7 +114,7 @@ object JsonAssertionOps {
       * Note that this logic is not appropriate for production code. Here we need to throw in order to fail incorrect
       * tests, but production code would use ValidatedNel.
       */
-    def strictDeepMerge(mainJson2: JsValue)(implicit pos: Position): JsValue = {
+    def strictDeepMerge(mainJson2: JsValue)(implicit @unused pos: Position): JsValue = {
 
       def recursive(json1: JsValue, json2: JsValue, path: JsPath): JsValue =
         (json1, json2) match {

--- a/it/test/uk/gov/hmrc/timetopayproxy/testutils/JsonAssertionOpsSpec.scala
+++ b/it/test/uk/gov/hmrc/timetopayproxy/testutils/JsonAssertionOpsSpec.scala
@@ -18,8 +18,8 @@ package uk.gov.hmrc.timetopayproxy.testutils
 
 import org.scalatest.exceptions.TestFailedException
 import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers._
-import play.api.libs.json._
+import org.scalatest.matchers.should.Matchers.*
+import play.api.libs.json.*
 
 final class JsonAssertionOpsSpec extends AnyFreeSpec {
   "JsonAssertionOps" - {
@@ -42,9 +42,8 @@ final class JsonAssertionOpsSpec extends AnyFreeSpec {
           )
 
           for ((value1, value2) <- cases)
-            s"for $value1 and $value2" in {
+            s"for $value1 and $value2" in
               value1.shouldBeEquivalentTo(value2)
-            }
         }
 
         "for two different simple JSON values" - {
@@ -105,35 +104,35 @@ final class JsonAssertionOpsSpec extends AnyFreeSpec {
           // Mind the sorting of the object fields! (for determinism and easier JSON test maintenance)
           exception.getMessage() shouldBe
             s"""{
-               |  "field1" : [
-               |    "abc",
-               |    1,
-               |    false,
-               |    null,
-               |    true,
-               |    {
-               |      "field1" : "value",
-               |      "field2" : "value"
-               |    }
-               |  ],
-               |  "field2" : [
-               |    "def"
-               |  ],
-               |  "field3" : [
-               |    {
-               |      "field1" : "value"
-               |    },
-               |    {
-               |      "field2" : "value"
-               |    }
-               |  ]
-               |}
-               | was not equal to {
-               |  "field1" : [
-               |    "abc"
-               |  ]
-               |}
-               |""".stripMargin
+              |  "field1" : [
+              |    "abc",
+              |    1,
+              |    false,
+              |    null,
+              |    true,
+              |    {
+              |      "field1" : "value",
+              |      "field2" : "value"
+              |    }
+              |  ],
+              |  "field2" : [
+              |    "def"
+              |  ],
+              |  "field3" : [
+              |    {
+              |      "field1" : "value"
+              |    },
+              |    {
+              |      "field2" : "value"
+              |    }
+              |  ]
+              |}
+              | was not equal to {
+              |  "field1" : [
+              |    "abc"
+              |  ]
+              |}
+              |""".stripMargin
         }
       }
     }

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -14,22 +14,22 @@ object AppDependencies {
   )
 
   val test = Seq(
-    "uk.gov.hmrc"                  %% "bootstrap-test-play-30"      % BootstrapPlayVersion % Test,
-    "org.scalatest"                %% "scalatest"                   % "3.2.20"             % Test,
-    "org.scalamock"                %% "scalamock"                   % "7.5.5"              % Test,
-    "org.playframework"            %% "play-test"                   % PlayVersion.current  % Test,
-    "com.fasterxml.jackson.module" %% "jackson-module-scala"        % "2.20.2"             % Test,
-    "com.vladsch.flexmark"          % "flexmark-all"                % "0.64.8"             % Test,
-    "org.scalatestplus.play"       %% "scalatestplus-play"          % "7.0.2"              % Test,
-    "com.networknt"                 % "json-schema-validator"       % "2.0.4"              % Test,
-    "com.softwaremill.quicklens"   %% "quicklens"                   % "1.9.12"             % Test
+    "uk.gov.hmrc"                  %% "bootstrap-test-play-30" % BootstrapPlayVersion % Test,
+    "org.scalatest"                %% "scalatest"              % "3.2.20"             % Test,
+    "org.scalamock"                %% "scalamock"              % "7.5.5"              % Test,
+    "org.playframework"            %% "play-test"              % PlayVersion.current  % Test,
+    "com.fasterxml.jackson.module" %% "jackson-module-scala"   % "2.20.2"             % Test,
+    "com.vladsch.flexmark"          % "flexmark-all"           % "0.64.8"             % Test,
+    "org.scalatestplus.play"       %% "scalatestplus-play"     % "7.0.2"              % Test,
+    "com.networknt"                 % "json-schema-validator"  % "2.0.4"              % Test,
+    "com.softwaremill.quicklens"   %% "quicklens"              % "1.9.12"             % Test
   )
 
   val dependencyOverrides = Seq(
-    "com.fasterxml.jackson.module"  % "jackson-module-scala_2.13" % "2.15.4",
-    "com.fasterxml.jackson.core"    % "jackson-databind"          % "2.15.4",
-    "uk.gov.hmrc"                   % "http-verbs-play-30_2.13"   % "15.8.0",
-    "org.slf4j"                     % "slf4j-api"                 % "2.0.17",
-    "com.google.guava"              % "guava"                     % "32.1.3-jre"
+    "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.20.2",
+    "com.fasterxml.jackson.core"    % "jackson-databind"     % "2.20.2",
+    "uk.gov.hmrc"                  %% "http-verbs-play-30"   % "15.8.0",
+    "org.slf4j"                     % "slf4j-api"            % "2.0.17",
+    "com.google.guava"              % "guava"                % "32.1.3-jre"
   )
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.12.9
+sbt.version=1.12.15

--- a/test/uk/gov/hmrc/timetopayproxy/actions/auth/ReadAuthoriseActionSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/actions/auth/ReadAuthoriseActionSpec.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.timetopayproxy.actions.auth
 
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import org.scalatest.matchers.should.Matchers.shouldBe
 import play.api.http.Status
 import play.api.mvc.{ Action, AnyContent, InjectedController }
 import play.api.test.Helpers.{ await, stubControllerComponents }

--- a/test/uk/gov/hmrc/timetopayproxy/actions/correlationid/CorrelationIdPopulationActionSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/actions/correlationid/CorrelationIdPopulationActionSpec.scala
@@ -21,7 +21,7 @@ import ch.qos.logback.classic.{ Level, Logger }
 import ch.qos.logback.core.read.ListAppender
 import org.scalatest.concurrent.ScalaFutures.convertScalaFuture
 import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers._
+import org.scalatest.matchers.should.Matchers.*
 import org.slf4j.LoggerFactory
 import play.api.mvc.Request
 import play.api.test.FakeRequest
@@ -30,6 +30,7 @@ import java.util.UUID
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.jdk.CollectionConverters.ListHasAsScala
+import scala.language.adhocExtensions
 
 class CorrelationIdPopulationActionSpec extends AnyFreeSpec {
 

--- a/test/uk/gov/hmrc/timetopayproxy/connectors/MockAppConfig.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/connectors/MockAppConfig.scala
@@ -20,6 +20,8 @@ import play.api.Configuration
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 import uk.gov.hmrc.timetopayproxy.config.AppConfig
 
+import scala.language.adhocExtensions
+
 class MockAppConfig(
   config: Configuration,
   servicesConfig: ServicesConfig,

--- a/test/uk/gov/hmrc/timetopayproxy/connectors/TtpConnectorSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/connectors/TtpConnectorSpec.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.timetopayproxy.connectors
 
 import org.scalamock.scalatest.MockFactory
+import org.scalatest.Inside.inside
 import org.scalatestplus.play.PlaySpec
 import play.api.libs.json.Json
 import play.api.test.{ DefaultAwaitTimeout, FutureAwaits }
@@ -25,7 +26,7 @@ import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 import uk.gov.hmrc.timetopayproxy.config.{ AppConfig, FeatureSwitch }
-import uk.gov.hmrc.timetopayproxy.models._
+import uk.gov.hmrc.timetopayproxy.models.*
 import uk.gov.hmrc.timetopayproxy.models.affordablequotes.{ AffordableQuoteResponse, AffordableQuotesRequest }
 import uk.gov.hmrc.timetopayproxy.models.error.ConnectorError
 import uk.gov.hmrc.timetopayproxy.models.featureSwitches.InternalAuthEnabled
@@ -339,7 +340,7 @@ class TtpConnectorSpec extends PlaySpec with DefaultAwaitTimeout with FutureAwai
         affordableQuotesRequest = affordableQuotesRequest
       )
 
-      await(result.value) must matchPattern { case Right(_: AffordableQuoteResponse) => }
+      inside(await(result.value)) { case Right(_: AffordableQuoteResponse) => }
     }
 
     "parse an error response from an upstream service" in new Setup() {
@@ -359,13 +360,13 @@ class TtpConnectorSpec extends PlaySpec with DefaultAwaitTimeout with FutureAwai
 
   private def errorResponse(code: String, reason: String): String =
     s"""
-       |{
-       | "failures":[
-       |   {
-       |     "code":"$code",
-       |     "reason":"$reason"
-       |   }
-       | ]
-       |}
-       |""".stripMargin
+      |{
+      | "failures":[
+      |   {
+      |     "code":"$code",
+      |     "reason":"$reason"
+      |   }
+      | ]
+      |}
+      |""".stripMargin
 }

--- a/test/uk/gov/hmrc/timetopayproxy/connectors/TtpFeedbackLoopConnectorSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/connectors/TtpFeedbackLoopConnectorSpec.scala
@@ -18,8 +18,8 @@ package uk.gov.hmrc.timetopayproxy.connectors
 
 import cats.data.NonEmptyList
 import org.scalamock.scalatest.MockFactory
-import org.scalatest.concurrent.ScalaFutures._
-import org.scalatest.matchers.should.Matchers._
+import org.scalatest.concurrent.ScalaFutures.*
+import org.scalatest.matchers.should.Matchers.*
 import org.scalatestplus.play.PlaySpec
 import play.api.libs.json.{ Json, Writes }
 import play.api.test.{ DefaultAwaitTimeout, FutureAwaits }
@@ -28,16 +28,16 @@ import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 import uk.gov.hmrc.timetopayproxy.config.{ AppConfig, FeatureSwitch }
-import uk.gov.hmrc.timetopayproxy.models._
+import uk.gov.hmrc.timetopayproxy.models.*
 import uk.gov.hmrc.timetopayproxy.models.currency.GbpPounds
 import uk.gov.hmrc.timetopayproxy.models.error.ConnectorError
 import uk.gov.hmrc.timetopayproxy.models.error.TtppEnvelope.TtppEnvelope
 import uk.gov.hmrc.timetopayproxy.models.featureSwitches.InternalAuthEnabled
-import uk.gov.hmrc.timetopayproxy.models.saonly.common._
+import uk.gov.hmrc.timetopayproxy.models.saonly.common.*
 import uk.gov.hmrc.timetopayproxy.models.saonly.common.apistatus.{ ApiName, ApiStatus, ApiStatusCode }
-import uk.gov.hmrc.timetopayproxy.models.saonly.ttpcancel._
-import uk.gov.hmrc.timetopayproxy.models.saonly.ttpfullamend._
-import uk.gov.hmrc.timetopayproxy.models.saonly.ttpinform._
+import uk.gov.hmrc.timetopayproxy.models.saonly.ttpcancel.*
+import uk.gov.hmrc.timetopayproxy.models.saonly.ttpfullamend.*
+import uk.gov.hmrc.timetopayproxy.models.saonly.ttpinform.*
 import uk.gov.hmrc.timetopayproxy.support.WireMockUtils
 
 import java.time.{ Instant, LocalDate }

--- a/test/uk/gov/hmrc/timetopayproxy/connectors/TtpeConnectorSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/connectors/TtpeConnectorSpec.scala
@@ -30,7 +30,7 @@ import uk.gov.hmrc.timetopayproxy.config.{ AppConfig, FeatureSwitch }
 import uk.gov.hmrc.timetopayproxy.models.error.{ ConnectorError, ProxyEnvelopeError }
 import uk.gov.hmrc.timetopayproxy.models.error.TtppEnvelope.TtppEnvelope
 import uk.gov.hmrc.timetopayproxy.models.featureSwitches.{ InternalAuthEnabled, SaRelease2Enabled }
-import uk.gov.hmrc.timetopayproxy.models.saonly.chargeInfoApi._
+import uk.gov.hmrc.timetopayproxy.models.saonly.chargeInfoApi.*
 import uk.gov.hmrc.timetopayproxy.models.saonly.common.SaOnlyRegimeType
 import uk.gov.hmrc.timetopayproxy.models.{ ChargeTypesExcluded, IdType, IdValue, Identification }
 import uk.gov.hmrc.timetopayproxy.support.WireMockUtils
@@ -308,11 +308,11 @@ class TtpeConnectorSpec
 
         def errorResponse(code: String, reason: String): String =
           s"""
-             |{
-             |  "code":"$code",
-             |  "reason":"$reason"
-             |}
-             |""".stripMargin
+            |{
+            |  "code":"$code",
+            |  "reason":"$reason"
+            |}
+            |""".stripMargin
 
         stubPostWithResponseBody(
           "/debts/time-to-pay/charge-info",
@@ -334,10 +334,10 @@ class TtpeConnectorSpec
           "/debts/time-to-pay/charge-info",
           422,
           s"""{
-             |  "code":"UNPROCESSABLE_CONTENT",
-             |  "reason":"Charges with the same charge reference do not share the same data"
-             |}
-             |""".stripMargin
+            |  "code":"UNPROCESSABLE_CONTENT",
+            |  "reason":"Charges with the same charge reference do not share the same data"
+            |}
+            |""".stripMargin
         )
 
         val result: TtppEnvelope[ChargeInfoResponse] = connector.checkChargeInfo(chargeInfoRequest = chargeInfoRequest)

--- a/test/uk/gov/hmrc/timetopayproxy/connectors/util/httpreadsbuilder/HttpReadsBuilderSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/connectors/util/httpreadsbuilder/HttpReadsBuilderSpec.scala
@@ -19,8 +19,8 @@ package uk.gov.hmrc.timetopayproxy.connectors.util.httpreadsbuilder
 import org.apache.pekko.http.scaladsl.model.{ StatusCode, StatusCodes }
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers._
-import org.slf4j.{ Logger => Slf4jLogger }
+import org.scalatest.matchers.should.Matchers.*
+import org.slf4j.Logger as Slf4jLogger
 import play.api.Logger
 import play.api.http.Status
 import play.api.libs.json.{ Json, OFormat }
@@ -72,7 +72,7 @@ final class HttpReadsBuilderSpec extends AnyFreeSpec with MockFactory {
         stringRepr(builderError)
 
       def stringRepr[ServiceError >: String](builderError: Any): ServiceError =
-        builderError match {
+        builderError.asInstanceOf[Matchable] match {
           case ResponseContext(method, url, response) =>
             val headerLines = response.headers.flatMap(h => h._2.map((h._1, _))).map(h => s"${h._1}: ${h._2}").toList
             val bodyLines = List(if (response.body.nonEmpty) response.body else "<empty body>")
@@ -85,8 +85,8 @@ final class HttpReadsBuilderSpec extends AnyFreeSpec with MockFactory {
               List("===")
 
             s"""RESPONSE TO: $method $url
-               |${lines.mkString("\n")}""".stripMargin
-          case product: Product with HttpReadsBuilderError[_] =>
+              |${lines.mkString("\n")}""".stripMargin
+          case product: (Product & HttpReadsBuilderError[?]) =>
             val productPairs = product.productElementNames
               .zip(product.productIterator)
               .map(kv => s"${this.stringRepr(kv._1)} = ${this.stringRepr(kv._2)}")
@@ -370,7 +370,7 @@ final class HttpReadsBuilderSpec extends AnyFreeSpec with MockFactory {
             val classChainString: String =
               Iterator
                 // Start with this class, then its parent, then its parent's parent, forever. Lazily computed so it won't throw.
-                .iterate[Class[_]](this.getClass)(_.getDeclaringClass)
+                .iterate[Class[?]](this.getClass)(_.getDeclaringClass)
                 .takeWhile(_ != null)
                 // Written as a takeWhile instead of dropWhile so we won't empty it if this trait is extended elsewhere by mistake.
                 .takeWhile(_ !== classOf[TestDataForCombinations.type])
@@ -512,7 +512,7 @@ final class HttpReadsBuilderSpec extends AnyFreeSpec with MockFactory {
       }
 
       "(check the test data)" in {
-        import TestDataForCombinations._
+        import TestDataForCombinations.*
 
         unexpectedStatuses2xx should have size 96
         unexpectedStatusesNon2xx should have size 396
@@ -522,7 +522,7 @@ final class HttpReadsBuilderSpec extends AnyFreeSpec with MockFactory {
         // We won't test .httpReadsNoLogging here because how Kibana handles line breaks would be irrelevant for it.
 
         "then .httpReads" in new TestFixtureForHttpReads {
-          import TestDataForCombinations._
+          import TestDataForCombinations.*
 
           httpReads.read(
             "POST",
@@ -666,19 +666,19 @@ final class HttpReadsBuilderSpec extends AnyFreeSpec with MockFactory {
           // The plain log line must make sense and be readable when Kibana strips the line breaks.
           // The URLs should not touch any punctuation.
           stripped shouldBe List(
-            """ERROR | JSON structure is not valid in received HTTP response. Originally expected to turn response into a Right. Returning: [DEEMED SAFE BY TEST LOGIC] <ResponseBodyInvalidJsonStructure( #  sourceClass = class java.lang.Thread, #  responseContext = RESPONSE TO: POST https://some.domain/for-success-236-wrong-structure #  === #  HTTP 236 Custom Status # #  {} #  ===, #  whichEitherWasExpected = OriginallyMeantToBeRight, #  errs = List((/for236,List(JsonValidationError(List(error.path.missing),List())))) )> . Request made for received HTTP response: POST https://some.domain/for-success-236-wrong-structure . Received HTTP response status: 236. Received HTTP response body not logged for 2xx statuses.""",
+            """ERROR | JSON structure is not valid in received HTTP response. Originally expected to turn response into a Right. Returning: [DEEMED SAFE BY TEST LOGIC] <ResponseBodyInvalidJsonStructure( #  sourceClass = class java.lang.Thread, #  responseContext = RESPONSE TO: POST https://some.domain/for-success-236-wrong-structure #  === #  HTTP 236 Custom Status # #  {} #  ===, #  whichEitherWasExpected = OriginallyMeantToBeRight, #  errs = List((/for236,List(JsonValidationError(List(error.path.missing),ArraySeq())))) )> . Request made for received HTTP response: POST https://some.domain/for-success-236-wrong-structure . Received HTTP response status: 236. Received HTTP response body not logged for 2xx statuses.""",
             """ERROR | HTTP body is not JSON in received HTTP response. Originally expected to turn response into a Right. Returning: [DEEMED SAFE BY TEST LOGIC] <ResponseBodyNotJson( #  sourceClass = class java.lang.Thread, #  responseContext = RESPONSE TO: POST https://some.domain/for-success-236-not-json #  === #  HTTP 236 Custom Status # #  some body that's not JSON #  ===, #  whichEitherWasExpected = OriginallyMeantToBeRight, #  sensitiveException = com.fasterxml.jackson.core.JsonParseException: Unrecognized token 'some': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false') #   at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 5] )> . Request made for received HTTP response: POST https://some.domain/for-success-236-not-json . Received HTTP response status: 236. Received HTTP response body not logged for 2xx statuses.""",
             """ERROR | Body of received HTTP response is not empty. Originally expected to turn response into a Right. Returning: [DEEMED SAFE BY TEST LOGIC] <ResponseBodyNotEmpty( #  sourceClass = class java.lang.Thread, #  responseContext = RESPONSE TO: POST https://some.domain/for-success-265-wrong-structure #  === #  HTTP 265 Custom Status # #  {} #  ===, #  whichEitherWasExpected = OriginallyMeantToBeRight )> . Request made for received HTTP response: POST https://some.domain/for-success-265-wrong-structure . Received HTTP response status: 265. Received HTTP response body not logged for 2xx statuses.""",
             """ERROR | Body of received HTTP response is not empty. Originally expected to turn response into a Right. Returning: [DEEMED SAFE BY TEST LOGIC] <ResponseBodyNotEmpty( #  sourceClass = class java.lang.Thread, #  responseContext = RESPONSE TO: POST https://some.domain/for-success-265-not-json #  === #  HTTP 265 Custom Status # #  some body that's not JSON #  ===, #  whichEitherWasExpected = OriginallyMeantToBeRight )> . Request made for received HTTP response: POST https://some.domain/for-success-265-not-json . Received HTTP response status: 265. Received HTTP response body not logged for 2xx statuses.""",
-            """ERROR | JSON structure is not valid in received HTTP response. Originally expected to turn response into a Right. Detail: Validation errors:     - For path /for419 , errors: [error.path.missing]. Returning: [DEEMED SAFE BY TEST LOGIC] <ResponseBodyInvalidJsonStructure( #  sourceClass = class java.lang.Thread, #  responseContext = RESPONSE TO: POST https://some.domain/for-success-419-wrong-structure #  === #  HTTP 419 Custom Status # #  {} #  ===, #  whichEitherWasExpected = OriginallyMeantToBeRight, #  errs = List((/for419,List(JsonValidationError(List(error.path.missing),List())))) )> . Request made for received HTTP response: POST https://some.domain/for-success-419-wrong-structure . Received HTTP response status: 419. Received HTTP response body: {}""",
+            """ERROR | JSON structure is not valid in received HTTP response. Originally expected to turn response into a Right. Detail: Validation errors:     - For path /for419 , errors: [error.path.missing]. Returning: [DEEMED SAFE BY TEST LOGIC] <ResponseBodyInvalidJsonStructure( #  sourceClass = class java.lang.Thread, #  responseContext = RESPONSE TO: POST https://some.domain/for-success-419-wrong-structure #  === #  HTTP 419 Custom Status # #  {} #  ===, #  whichEitherWasExpected = OriginallyMeantToBeRight, #  errs = List((/for419,List(JsonValidationError(List(error.path.missing),ArraySeq())))) )> . Request made for received HTTP response: POST https://some.domain/for-success-419-wrong-structure . Received HTTP response status: 419. Received HTTP response body: {}""",
             """ERROR | HTTP body is not JSON in received HTTP response. Originally expected to turn response into a Right. Detail: com.fasterxml.jackson.core.JsonParseException: Unrecognized token 'some': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')  at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 5] Returning: [DEEMED SAFE BY TEST LOGIC] <ResponseBodyNotJson( #  sourceClass = class java.lang.Thread, #  responseContext = RESPONSE TO: POST https://some.domain/for-success-419-not-json #  === #  HTTP 419 Custom Status # #  some body that's not JSON #  ===, #  whichEitherWasExpected = OriginallyMeantToBeRight, #  sensitiveException = com.fasterxml.jackson.core.JsonParseException: Unrecognized token 'some': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false') #   at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 5] )> . Request made for received HTTP response: POST https://some.domain/for-success-419-not-json . Received HTTP response status: 419. Received HTTP response body: some body that's not JSON""",
             """ERROR | Body of received HTTP response is not empty. Originally expected to turn response into a Right. Returning: [DEEMED SAFE BY TEST LOGIC] <ResponseBodyNotEmpty( #  sourceClass = class java.lang.Thread, #  responseContext = RESPONSE TO: POST https://some.domain/for-success-445-wrong-structure #  === #  HTTP 445 Custom Status # #  {} #  ===, #  whichEitherWasExpected = OriginallyMeantToBeRight )> . Request made for received HTTP response: POST https://some.domain/for-success-445-wrong-structure . Received HTTP response status: 445. Received HTTP response body: {}""",
             """ERROR | Body of received HTTP response is not empty. Originally expected to turn response into a Right. Returning: [DEEMED SAFE BY TEST LOGIC] <ResponseBodyNotEmpty( #  sourceClass = class java.lang.Thread, #  responseContext = RESPONSE TO: POST https://some.domain/for-success-445-not-json #  === #  HTTP 445 Custom Status # #  some body that's not JSON #  ===, #  whichEitherWasExpected = OriginallyMeantToBeRight )> . Request made for received HTTP response: POST https://some.domain/for-success-445-not-json . Received HTTP response status: 445. Received HTTP response body: some body that's not JSON""",
             """WARN | Valid and expected error response was received from HTTP call. Request made for received HTTP response: POST https://some.domain/for-failure-109-correct-structure-for-warning-log . Received HTTP response status: 109. Received HTTP response body: {"for109":"example"}""",
-            """ERROR | JSON structure is not valid in received HTTP response. Originally expected to turn response into a Left. Detail: Validation errors:     - For path /for109 , errors: [error.path.missing]. Returning: [DEEMED SAFE BY TEST LOGIC] <ResponseBodyInvalidJsonStructure( #  sourceClass = class java.lang.Thread, #  responseContext = RESPONSE TO: POST https://some.domain/for-failure-109-wrong-structure #  === #  HTTP 109 Custom Status # #  {} #  ===, #  whichEitherWasExpected = OriginallyMeantToBeLeft, #  errs = List((/for109,List(JsonValidationError(List(error.path.missing),List())))) )> . Request made for received HTTP response: POST https://some.domain/for-failure-109-wrong-structure . Received HTTP response status: 109. Received HTTP response body: {}""",
+            """ERROR | JSON structure is not valid in received HTTP response. Originally expected to turn response into a Left. Detail: Validation errors:     - For path /for109 , errors: [error.path.missing]. Returning: [DEEMED SAFE BY TEST LOGIC] <ResponseBodyInvalidJsonStructure( #  sourceClass = class java.lang.Thread, #  responseContext = RESPONSE TO: POST https://some.domain/for-failure-109-wrong-structure #  === #  HTTP 109 Custom Status # #  {} #  ===, #  whichEitherWasExpected = OriginallyMeantToBeLeft, #  errs = List((/for109,List(JsonValidationError(List(error.path.missing),ArraySeq())))) )> . Request made for received HTTP response: POST https://some.domain/for-failure-109-wrong-structure . Received HTTP response status: 109. Received HTTP response body: {}""",
             """ERROR | HTTP body is not JSON in received HTTP response. Originally expected to turn response into a Left. Detail: com.fasterxml.jackson.core.JsonParseException: Unrecognized token 'some': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')  at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 5] Returning: [DEEMED SAFE BY TEST LOGIC] <ResponseBodyNotJson( #  sourceClass = class java.lang.Thread, #  responseContext = RESPONSE TO: POST https://some.domain/for-failure-109-not-json #  === #  HTTP 109 Custom Status # #  some body that's not JSON #  ===, #  whichEitherWasExpected = OriginallyMeantToBeLeft, #  sensitiveException = com.fasterxml.jackson.core.JsonParseException: Unrecognized token 'some': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false') #   at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 5] )> . Request made for received HTTP response: POST https://some.domain/for-failure-109-not-json . Received HTTP response status: 109. Received HTTP response body: some body that's not JSON""",
             """WARN | Valid and expected error response was received from HTTP call. Request made for received HTTP response: POST https://some.domain/for-failure-211-correct-structure-for-warning-log . Received HTTP response status: 211. Received HTTP response body not logged for 2xx statuses.""",
-            """ERROR | JSON structure is not valid in received HTTP response. Originally expected to turn response into a Left. Returning: [DEEMED SAFE BY TEST LOGIC] <ResponseBodyInvalidJsonStructure( #  sourceClass = class java.lang.Thread, #  responseContext = RESPONSE TO: POST https://some.domain/for-failure-211-wrong-structure #  === #  HTTP 211 Custom Status # #  {} #  ===, #  whichEitherWasExpected = OriginallyMeantToBeLeft, #  errs = List((/for211,List(JsonValidationError(List(error.path.missing),List())))) )> . Request made for received HTTP response: POST https://some.domain/for-failure-211-wrong-structure . Received HTTP response status: 211. Received HTTP response body not logged for 2xx statuses.""",
+            """ERROR | JSON structure is not valid in received HTTP response. Originally expected to turn response into a Left. Returning: [DEEMED SAFE BY TEST LOGIC] <ResponseBodyInvalidJsonStructure( #  sourceClass = class java.lang.Thread, #  responseContext = RESPONSE TO: POST https://some.domain/for-failure-211-wrong-structure #  === #  HTTP 211 Custom Status # #  {} #  ===, #  whichEitherWasExpected = OriginallyMeantToBeLeft, #  errs = List((/for211,List(JsonValidationError(List(error.path.missing),ArraySeq())))) )> . Request made for received HTTP response: POST https://some.domain/for-failure-211-wrong-structure . Received HTTP response status: 211. Received HTTP response body not logged for 2xx statuses.""",
             """ERROR | HTTP body is not JSON in received HTTP response. Originally expected to turn response into a Left. Returning: [DEEMED SAFE BY TEST LOGIC] <ResponseBodyNotJson( #  sourceClass = class java.lang.Thread, #  responseContext = RESPONSE TO: POST https://some.domain/for-failure-211-not-json #  === #  HTTP 211 Custom Status # #  some body that's not JSON #  ===, #  whichEitherWasExpected = OriginallyMeantToBeLeft, #  sensitiveException = com.fasterxml.jackson.core.JsonParseException: Unrecognized token 'some': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false') #   at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 5] )> . Request made for received HTTP response: POST https://some.domain/for-failure-211-not-json . Received HTTP response status: 211. Received HTTP response body not logged for 2xx statuses.""",
             """WARN | Valid and expected error response was received from HTTP call. Request made for received HTTP response: POST https://some.domain/for-failure-277-correct-structure-for-warning-log . Received HTTP response status: 277. Received HTTP response body not logged for 2xx statuses.""",
             """ERROR | Body of received HTTP response is not empty. Originally expected to turn response into a Left. Returning: [DEEMED SAFE BY TEST LOGIC] <ResponseBodyNotEmpty( #  sourceClass = class java.lang.Thread, #  responseContext = RESPONSE TO: POST https://some.domain/for-failure-277-wrong-structure #  === #  HTTP 277 Custom Status # #  {} #  ===, #  whichEitherWasExpected = OriginallyMeantToBeLeft )> . Request made for received HTTP response: POST https://some.domain/for-failure-277-wrong-structure . Received HTTP response status: 277. Received HTTP response body not logged for 2xx statuses.""",
@@ -758,27 +758,27 @@ final class HttpReadsBuilderSpec extends AnyFreeSpec with MockFactory {
                   |#  {}
                   |#  ===,
                   |#  whichEitherWasExpected = OriginallyMeantToBeRight,
-                  |#  errs = List((/for236,List(JsonValidationError(List(error.path.missing),List()))))
+                  |#  errs = List((/for236,List(JsonValidationError(List(error.path.missing),ArraySeq()))))
                   |)""".stripMargin
               )
 
               allCapturedLogs shouldBe List(
                 "ERROR" ->
                   s"""JSON structure is not valid in received HTTP response. Originally expected to turn response into a Right.
-                     |Returning: [DEEMED SAFE BY TEST LOGIC] <ResponseBodyInvalidJsonStructure(
-                     |#  sourceClass = class java.lang.Thread,
-                     |#  responseContext = RESPONSE TO: MYMETHOD some/url
-                     |#  ===
-                     |#  HTTP 236 Custom Status
-                     |#
-                     |#  {}
-                     |#  ===,
-                     |#  whichEitherWasExpected = OriginallyMeantToBeRight,
-                     |#  errs = List((/for236,List(JsonValidationError(List(error.path.missing),List()))))
-                     |)> .
-                     |Request made for received HTTP response: MYMETHOD some/url .
-                     |Received HTTP response status: 236.
-                     |Received HTTP response body not logged for 2xx statuses.""".stripMargin
+                    |Returning: [DEEMED SAFE BY TEST LOGIC] <ResponseBodyInvalidJsonStructure(
+                    |#  sourceClass = class java.lang.Thread,
+                    |#  responseContext = RESPONSE TO: MYMETHOD some/url
+                    |#  ===
+                    |#  HTTP 236 Custom Status
+                    |#
+                    |#  {}
+                    |#  ===,
+                    |#  whichEitherWasExpected = OriginallyMeantToBeRight,
+                    |#  errs = List((/for236,List(JsonValidationError(List(error.path.missing),ArraySeq()))))
+                    |)> .
+                    |Request made for received HTTP response: MYMETHOD some/url .
+                    |Received HTTP response status: 236.
+                    |Received HTTP response body not logged for 2xx statuses.""".stripMargin
               )
             }
 
@@ -798,7 +798,7 @@ final class HttpReadsBuilderSpec extends AnyFreeSpec with MockFactory {
                   |#  {}
                   |#  ===,
                   |#  whichEitherWasExpected = OriginallyMeantToBeRight,
-                  |#  errs = List((/for236,List(JsonValidationError(List(error.path.missing),List()))))
+                  |#  errs = List((/for236,List(JsonValidationError(List(error.path.missing),ArraySeq()))))
                   |)""".stripMargin
               )
 
@@ -830,19 +830,19 @@ final class HttpReadsBuilderSpec extends AnyFreeSpec with MockFactory {
               allCapturedLogs shouldBe List(
                 "ERROR" ->
                   s"""Body of received HTTP response is not empty. Originally expected to turn response into a Right.
-                     |Returning: [DEEMED SAFE BY TEST LOGIC] <ResponseBodyNotEmpty(
-                     |#  sourceClass = class java.lang.Thread,
-                     |#  responseContext = RESPONSE TO: MYMETHOD some/url
-                     |#  ===
-                     |#  HTTP 265 Custom Status
-                     |#
-                     |#  {}
-                     |#  ===,
-                     |#  whichEitherWasExpected = OriginallyMeantToBeRight
-                     |)> .
-                     |Request made for received HTTP response: MYMETHOD some/url .
-                     |Received HTTP response status: 265.
-                     |Received HTTP response body not logged for 2xx statuses.""".stripMargin
+                    |Returning: [DEEMED SAFE BY TEST LOGIC] <ResponseBodyNotEmpty(
+                    |#  sourceClass = class java.lang.Thread,
+                    |#  responseContext = RESPONSE TO: MYMETHOD some/url
+                    |#  ===
+                    |#  HTTP 265 Custom Status
+                    |#
+                    |#  {}
+                    |#  ===,
+                    |#  whichEitherWasExpected = OriginallyMeantToBeRight
+                    |)> .
+                    |Request made for received HTTP response: MYMETHOD some/url .
+                    |Received HTTP response status: 265.
+                    |Received HTTP response body not logged for 2xx statuses.""".stripMargin
               )
             }
 
@@ -887,29 +887,29 @@ final class HttpReadsBuilderSpec extends AnyFreeSpec with MockFactory {
                   |#  {}
                   |#  ===,
                   |#  whichEitherWasExpected = OriginallyMeantToBeRight,
-                  |#  errs = List((/for419,List(JsonValidationError(List(error.path.missing),List()))))
+                  |#  errs = List((/for419,List(JsonValidationError(List(error.path.missing),ArraySeq()))))
                   |)""".stripMargin
               )
 
               allCapturedLogs shouldBe List(
                 "ERROR" ->
                   s"""JSON structure is not valid in received HTTP response. Originally expected to turn response into a Right.
-                     |Detail: Validation errors:
-                     |    - For path /for419 , errors: [error.path.missing].
-                     |Returning: [DEEMED SAFE BY TEST LOGIC] <ResponseBodyInvalidJsonStructure(
-                     |#  sourceClass = class java.lang.Thread,
-                     |#  responseContext = RESPONSE TO: MYMETHOD some/url
-                     |#  ===
-                     |#  HTTP 419 Custom Status
-                     |#
-                     |#  {}
-                     |#  ===,
-                     |#  whichEitherWasExpected = OriginallyMeantToBeRight,
-                     |#  errs = List((/for419,List(JsonValidationError(List(error.path.missing),List()))))
-                     |)> .
-                     |Request made for received HTTP response: MYMETHOD some/url .
-                     |Received HTTP response status: 419.
-                     |Received HTTP response body: {}""".stripMargin
+                    |Detail: Validation errors:
+                    |    - For path /for419 , errors: [error.path.missing].
+                    |Returning: [DEEMED SAFE BY TEST LOGIC] <ResponseBodyInvalidJsonStructure(
+                    |#  sourceClass = class java.lang.Thread,
+                    |#  responseContext = RESPONSE TO: MYMETHOD some/url
+                    |#  ===
+                    |#  HTTP 419 Custom Status
+                    |#
+                    |#  {}
+                    |#  ===,
+                    |#  whichEitherWasExpected = OriginallyMeantToBeRight,
+                    |#  errs = List((/for419,List(JsonValidationError(List(error.path.missing),ArraySeq()))))
+                    |)> .
+                    |Request made for received HTTP response: MYMETHOD some/url .
+                    |Received HTTP response status: 419.
+                    |Received HTTP response body: {}""".stripMargin
               )
             }
 
@@ -929,7 +929,7 @@ final class HttpReadsBuilderSpec extends AnyFreeSpec with MockFactory {
                   |#  {}
                   |#  ===,
                   |#  whichEitherWasExpected = OriginallyMeantToBeRight,
-                  |#  errs = List((/for419,List(JsonValidationError(List(error.path.missing),List()))))
+                  |#  errs = List((/for419,List(JsonValidationError(List(error.path.missing),ArraySeq()))))
                   |)""".stripMargin
               )
 
@@ -961,19 +961,19 @@ final class HttpReadsBuilderSpec extends AnyFreeSpec with MockFactory {
               allCapturedLogs shouldBe List(
                 "ERROR" ->
                   s"""Body of received HTTP response is not empty. Originally expected to turn response into a Right.
-                     |Returning: [DEEMED SAFE BY TEST LOGIC] <ResponseBodyNotEmpty(
-                     |#  sourceClass = class java.lang.Thread,
-                     |#  responseContext = RESPONSE TO: MYMETHOD some/url
-                     |#  ===
-                     |#  HTTP 445 Custom Status
-                     |#
-                     |#  {}
-                     |#  ===,
-                     |#  whichEitherWasExpected = OriginallyMeantToBeRight
-                     |)> .
-                     |Request made for received HTTP response: MYMETHOD some/url .
-                     |Received HTTP response status: 445.
-                     |Received HTTP response body: {}""".stripMargin
+                    |Returning: [DEEMED SAFE BY TEST LOGIC] <ResponseBodyNotEmpty(
+                    |#  sourceClass = class java.lang.Thread,
+                    |#  responseContext = RESPONSE TO: MYMETHOD some/url
+                    |#  ===
+                    |#  HTTP 445 Custom Status
+                    |#
+                    |#  {}
+                    |#  ===,
+                    |#  whichEitherWasExpected = OriginallyMeantToBeRight
+                    |)> .
+                    |Request made for received HTTP response: MYMETHOD some/url .
+                    |Received HTTP response status: 445.
+                    |Received HTTP response body: {}""".stripMargin
               )
             }
 
@@ -1028,21 +1028,21 @@ final class HttpReadsBuilderSpec extends AnyFreeSpec with MockFactory {
               allCapturedLogs shouldBe List(
                 "ERROR" ->
                   s"""HTTP body is not JSON in received HTTP response. Originally expected to turn response into a Right.
-                     |Returning: [DEEMED SAFE BY TEST LOGIC] <ResponseBodyNotJson(
-                     |#  sourceClass = class java.lang.Thread,
-                     |#  responseContext = RESPONSE TO: MYMETHOD some/url
-                     |#  ===
-                     |#  HTTP 236 Custom Status
-                     |#
-                     |#  TEXT
-                     |#  ===,
-                     |#  whichEitherWasExpected = OriginallyMeantToBeRight,
-                     |#  sensitiveException = com.fasterxml.jackson.core.JsonParseException: Unrecognized token 'TEXT': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')
-                     |#   at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 5]
-                     |)> .
-                     |Request made for received HTTP response: MYMETHOD some/url .
-                     |Received HTTP response status: 236.
-                     |Received HTTP response body not logged for 2xx statuses.""".stripMargin
+                    |Returning: [DEEMED SAFE BY TEST LOGIC] <ResponseBodyNotJson(
+                    |#  sourceClass = class java.lang.Thread,
+                    |#  responseContext = RESPONSE TO: MYMETHOD some/url
+                    |#  ===
+                    |#  HTTP 236 Custom Status
+                    |#
+                    |#  TEXT
+                    |#  ===,
+                    |#  whichEitherWasExpected = OriginallyMeantToBeRight,
+                    |#  sensitiveException = com.fasterxml.jackson.core.JsonParseException: Unrecognized token 'TEXT': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')
+                    |#   at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 5]
+                    |)> .
+                    |Request made for received HTTP response: MYMETHOD some/url .
+                    |Received HTTP response status: 236.
+                    |Received HTTP response body not logged for 2xx statuses.""".stripMargin
               )
             }
 
@@ -1095,19 +1095,19 @@ final class HttpReadsBuilderSpec extends AnyFreeSpec with MockFactory {
               allCapturedLogs shouldBe List(
                 "ERROR" ->
                   s"""Body of received HTTP response is not empty. Originally expected to turn response into a Right.
-                     |Returning: [DEEMED SAFE BY TEST LOGIC] <ResponseBodyNotEmpty(
-                     |#  sourceClass = class java.lang.Thread,
-                     |#  responseContext = RESPONSE TO: MYMETHOD some/url
-                     |#  ===
-                     |#  HTTP 265 Custom Status
-                     |#
-                     |#  TEXT
-                     |#  ===,
-                     |#  whichEitherWasExpected = OriginallyMeantToBeRight
-                     |)> .
-                     |Request made for received HTTP response: MYMETHOD some/url .
-                     |Received HTTP response status: 265.
-                     |Received HTTP response body not logged for 2xx statuses.""".stripMargin
+                    |Returning: [DEEMED SAFE BY TEST LOGIC] <ResponseBodyNotEmpty(
+                    |#  sourceClass = class java.lang.Thread,
+                    |#  responseContext = RESPONSE TO: MYMETHOD some/url
+                    |#  ===
+                    |#  HTTP 265 Custom Status
+                    |#
+                    |#  TEXT
+                    |#  ===,
+                    |#  whichEitherWasExpected = OriginallyMeantToBeRight
+                    |)> .
+                    |Request made for received HTTP response: MYMETHOD some/url .
+                    |Received HTTP response status: 265.
+                    |Received HTTP response body not logged for 2xx statuses.""".stripMargin
               )
             }
 
@@ -1120,15 +1120,15 @@ final class HttpReadsBuilderSpec extends AnyFreeSpec with MockFactory {
 
               result shouldBe Left(
                 s"""ResponseBodyNotEmpty(
-                   |#  sourceClass = class java.lang.Thread,
-                   |#  responseContext = RESPONSE TO: MYMETHOD some/url
-                   |#  ===
-                   |#  HTTP 265 Custom Status
-                   |#
-                   |#  TEXT
-                   |#  ===,
-                   |#  whichEitherWasExpected = OriginallyMeantToBeRight
-                   |)""".stripMargin
+                  |#  sourceClass = class java.lang.Thread,
+                  |#  responseContext = RESPONSE TO: MYMETHOD some/url
+                  |#  ===
+                  |#  HTTP 265 Custom Status
+                  |#
+                  |#  TEXT
+                  |#  ===,
+                  |#  whichEitherWasExpected = OriginallyMeantToBeRight
+                  |)""".stripMargin
               )
 
               allCapturedLogs shouldBe Nil
@@ -1160,23 +1160,23 @@ final class HttpReadsBuilderSpec extends AnyFreeSpec with MockFactory {
               allCapturedLogs shouldBe List(
                 "ERROR" ->
                   s"""HTTP body is not JSON in received HTTP response. Originally expected to turn response into a Right.
-                     |Detail: com.fasterxml.jackson.core.JsonParseException: Unrecognized token 'TEXT': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')
-                     | at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 5]
-                     |Returning: [DEEMED SAFE BY TEST LOGIC] <ResponseBodyNotJson(
-                     |#  sourceClass = class java.lang.Thread,
-                     |#  responseContext = RESPONSE TO: MYMETHOD some/url
-                     |#  ===
-                     |#  HTTP 419 Custom Status
-                     |#
-                     |#  TEXT
-                     |#  ===,
-                     |#  whichEitherWasExpected = OriginallyMeantToBeRight,
-                     |#  sensitiveException = com.fasterxml.jackson.core.JsonParseException: Unrecognized token 'TEXT': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')
-                     |#   at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 5]
-                     |)> .
-                     |Request made for received HTTP response: MYMETHOD some/url .
-                     |Received HTTP response status: 419.
-                     |Received HTTP response body: TEXT""".stripMargin
+                    |Detail: com.fasterxml.jackson.core.JsonParseException: Unrecognized token 'TEXT': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')
+                    | at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 5]
+                    |Returning: [DEEMED SAFE BY TEST LOGIC] <ResponseBodyNotJson(
+                    |#  sourceClass = class java.lang.Thread,
+                    |#  responseContext = RESPONSE TO: MYMETHOD some/url
+                    |#  ===
+                    |#  HTTP 419 Custom Status
+                    |#
+                    |#  TEXT
+                    |#  ===,
+                    |#  whichEitherWasExpected = OriginallyMeantToBeRight,
+                    |#  sensitiveException = com.fasterxml.jackson.core.JsonParseException: Unrecognized token 'TEXT': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')
+                    |#   at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 5]
+                    |)> .
+                    |Request made for received HTTP response: MYMETHOD some/url .
+                    |Received HTTP response status: 419.
+                    |Received HTTP response body: TEXT""".stripMargin
               )
             }
 
@@ -1229,19 +1229,19 @@ final class HttpReadsBuilderSpec extends AnyFreeSpec with MockFactory {
               allCapturedLogs shouldBe List(
                 "ERROR" ->
                   s"""Body of received HTTP response is not empty. Originally expected to turn response into a Right.
-                     |Returning: [DEEMED SAFE BY TEST LOGIC] <ResponseBodyNotEmpty(
-                     |#  sourceClass = class java.lang.Thread,
-                     |#  responseContext = RESPONSE TO: MYMETHOD some/url
-                     |#  ===
-                     |#  HTTP 445 Custom Status
-                     |#
-                     |#  TEXT
-                     |#  ===,
-                     |#  whichEitherWasExpected = OriginallyMeantToBeRight
-                     |)> .
-                     |Request made for received HTTP response: MYMETHOD some/url .
-                     |Received HTTP response status: 445.
-                     |Received HTTP response body: TEXT""".stripMargin
+                    |Returning: [DEEMED SAFE BY TEST LOGIC] <ResponseBodyNotEmpty(
+                    |#  sourceClass = class java.lang.Thread,
+                    |#  responseContext = RESPONSE TO: MYMETHOD some/url
+                    |#  ===
+                    |#  HTTP 445 Custom Status
+                    |#
+                    |#  TEXT
+                    |#  ===,
+                    |#  whichEitherWasExpected = OriginallyMeantToBeRight
+                    |)> .
+                    |Request made for received HTTP response: MYMETHOD some/url .
+                    |Received HTTP response status: 445.
+                    |Received HTTP response body: TEXT""".stripMargin
               )
 
               allCapturedLogs.toString should include("TEXT") // This success is not a 2xx, so it's safe to log.
@@ -1293,9 +1293,9 @@ final class HttpReadsBuilderSpec extends AnyFreeSpec with MockFactory {
             allCapturedLogs shouldBe List(
               "WARN" ->
                 s"""Valid and expected error response was received from HTTP call.
-                   |Request made for received HTTP response: MYMETHOD some/url .
-                   |Received HTTP response status: 109.
-                   |Received HTTP response body: ${Err109Json.Wrapper.exampleBody: String}""".stripMargin
+                  |Request made for received HTTP response: MYMETHOD some/url .
+                  |Received HTTP response status: 109.
+                  |Received HTTP response body: ${Err109Json.Wrapper.exampleBody: String}""".stripMargin
             )
           }
         }
@@ -1316,29 +1316,29 @@ final class HttpReadsBuilderSpec extends AnyFreeSpec with MockFactory {
                 |#  {}
                 |#  ===,
                 |#  whichEitherWasExpected = OriginallyMeantToBeLeft,
-                |#  errs = List((/for109,List(JsonValidationError(List(error.path.missing),List()))))
+                |#  errs = List((/for109,List(JsonValidationError(List(error.path.missing),ArraySeq()))))
                 |)""".stripMargin
             )
 
             allCapturedLogs shouldBe List(
               "ERROR" ->
                 s"""JSON structure is not valid in received HTTP response. Originally expected to turn response into a Left.
-                   |Detail: Validation errors:
-                   |    - For path /for109 , errors: [error.path.missing].
-                   |Returning: [DEEMED SAFE BY TEST LOGIC] <ResponseBodyInvalidJsonStructure(
-                   |#  sourceClass = class java.lang.Thread,
-                   |#  responseContext = RESPONSE TO: MYMETHOD some/url
-                   |#  ===
-                   |#  HTTP 109 Custom Status
-                   |#
-                   |#  {}
-                   |#  ===,
-                   |#  whichEitherWasExpected = OriginallyMeantToBeLeft,
-                   |#  errs = List((/for109,List(JsonValidationError(List(error.path.missing),List()))))
-                   |)> .
-                   |Request made for received HTTP response: MYMETHOD some/url .
-                   |Received HTTP response status: 109.
-                   |Received HTTP response body: {}""".stripMargin
+                  |Detail: Validation errors:
+                  |    - For path /for109 , errors: [error.path.missing].
+                  |Returning: [DEEMED SAFE BY TEST LOGIC] <ResponseBodyInvalidJsonStructure(
+                  |#  sourceClass = class java.lang.Thread,
+                  |#  responseContext = RESPONSE TO: MYMETHOD some/url
+                  |#  ===
+                  |#  HTTP 109 Custom Status
+                  |#
+                  |#  {}
+                  |#  ===,
+                  |#  whichEitherWasExpected = OriginallyMeantToBeLeft,
+                  |#  errs = List((/for109,List(JsonValidationError(List(error.path.missing),ArraySeq()))))
+                  |)> .
+                  |Request made for received HTTP response: MYMETHOD some/url .
+                  |Received HTTP response status: 109.
+                  |Received HTTP response body: {}""".stripMargin
             )
           }
         }
@@ -1368,23 +1368,23 @@ final class HttpReadsBuilderSpec extends AnyFreeSpec with MockFactory {
             allCapturedLogs shouldBe List(
               "ERROR" ->
                 s"""HTTP body is not JSON in received HTTP response. Originally expected to turn response into a Left.
-                   |Detail: com.fasterxml.jackson.core.JsonParseException: Unrecognized token 'TEXT': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')
-                   | at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 5]
-                   |Returning: [DEEMED SAFE BY TEST LOGIC] <ResponseBodyNotJson(
-                   |#  sourceClass = class java.lang.Thread,
-                   |#  responseContext = RESPONSE TO: MYMETHOD some/url
-                   |#  ===
-                   |#  HTTP 109 Custom Status
-                   |#
-                   |#  TEXT
-                   |#  ===,
-                   |#  whichEitherWasExpected = OriginallyMeantToBeLeft,
-                   |#  sensitiveException = com.fasterxml.jackson.core.JsonParseException: Unrecognized token 'TEXT': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')
-                   |#   at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 5]
-                   |)> .
-                   |Request made for received HTTP response: MYMETHOD some/url .
-                   |Received HTTP response status: 109.
-                   |Received HTTP response body: TEXT""".stripMargin
+                  |Detail: com.fasterxml.jackson.core.JsonParseException: Unrecognized token 'TEXT': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')
+                  | at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 5]
+                  |Returning: [DEEMED SAFE BY TEST LOGIC] <ResponseBodyNotJson(
+                  |#  sourceClass = class java.lang.Thread,
+                  |#  responseContext = RESPONSE TO: MYMETHOD some/url
+                  |#  ===
+                  |#  HTTP 109 Custom Status
+                  |#
+                  |#  TEXT
+                  |#  ===,
+                  |#  whichEitherWasExpected = OriginallyMeantToBeLeft,
+                  |#  sensitiveException = com.fasterxml.jackson.core.JsonParseException: Unrecognized token 'TEXT': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')
+                  |#   at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 5]
+                  |)> .
+                  |Request made for received HTTP response: MYMETHOD some/url .
+                  |Received HTTP response status: 109.
+                  |Received HTTP response body: TEXT""".stripMargin
             )
           }
 
@@ -1415,9 +1415,9 @@ final class HttpReadsBuilderSpec extends AnyFreeSpec with MockFactory {
             allCapturedLogs shouldBe List(
               "WARN" ->
                 s"""Valid and expected error response was received from HTTP call.
-                   |Request made for received HTTP response: MYMETHOD some/url .
-                   |Received HTTP response status: 211.
-                   |Received HTTP response body not logged for 2xx statuses.""".stripMargin
+                  |Request made for received HTTP response: MYMETHOD some/url .
+                  |Received HTTP response status: 211.
+                  |Received HTTP response body not logged for 2xx statuses.""".stripMargin
             )
           }
         }
@@ -1439,27 +1439,27 @@ final class HttpReadsBuilderSpec extends AnyFreeSpec with MockFactory {
                 |#  {}
                 |#  ===,
                 |#  whichEitherWasExpected = OriginallyMeantToBeLeft,
-                |#  errs = List((/for211,List(JsonValidationError(List(error.path.missing),List()))))
+                |#  errs = List((/for211,List(JsonValidationError(List(error.path.missing),ArraySeq()))))
                 |)""".stripMargin
             )
 
             allCapturedLogs shouldBe List(
               "ERROR" ->
                 s"""JSON structure is not valid in received HTTP response. Originally expected to turn response into a Left.
-                   |Returning: [DEEMED SAFE BY TEST LOGIC] <ResponseBodyInvalidJsonStructure(
-                   |#  sourceClass = class java.lang.Thread,
-                   |#  responseContext = RESPONSE TO: MYMETHOD some/url
-                   |#  ===
-                   |#  HTTP 211 Custom Status
-                   |#
-                   |#  {}
-                   |#  ===,
-                   |#  whichEitherWasExpected = OriginallyMeantToBeLeft,
-                   |#  errs = List((/for211,List(JsonValidationError(List(error.path.missing),List()))))
-                   |)> .
-                   |Request made for received HTTP response: MYMETHOD some/url .
-                   |Received HTTP response status: 211.
-                   |Received HTTP response body not logged for 2xx statuses.""".stripMargin
+                  |Returning: [DEEMED SAFE BY TEST LOGIC] <ResponseBodyInvalidJsonStructure(
+                  |#  sourceClass = class java.lang.Thread,
+                  |#  responseContext = RESPONSE TO: MYMETHOD some/url
+                  |#  ===
+                  |#  HTTP 211 Custom Status
+                  |#
+                  |#  {}
+                  |#  ===,
+                  |#  whichEitherWasExpected = OriginallyMeantToBeLeft,
+                  |#  errs = List((/for211,List(JsonValidationError(List(error.path.missing),ArraySeq()))))
+                  |)> .
+                  |Request made for received HTTP response: MYMETHOD some/url .
+                  |Received HTTP response status: 211.
+                  |Received HTTP response body not logged for 2xx statuses.""".stripMargin
             )
           }
         }
@@ -1474,37 +1474,37 @@ final class HttpReadsBuilderSpec extends AnyFreeSpec with MockFactory {
 
             result shouldBe Left(
               s"""ResponseBodyNotJson(
-                 |#  sourceClass = class java.lang.Thread,
-                 |#  responseContext = RESPONSE TO: MYMETHOD some/url
-                 |#  ===
-                 |#  HTTP 211 Custom Status
-                 |#
-                 |#  TEXT
-                 |#  ===,
-                 |#  whichEitherWasExpected = OriginallyMeantToBeLeft,
-                 |#  sensitiveException = com.fasterxml.jackson.core.JsonParseException: Unrecognized token 'TEXT': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')
-                 |#   at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 5]
-                 |)""".stripMargin
+                |#  sourceClass = class java.lang.Thread,
+                |#  responseContext = RESPONSE TO: MYMETHOD some/url
+                |#  ===
+                |#  HTTP 211 Custom Status
+                |#
+                |#  TEXT
+                |#  ===,
+                |#  whichEitherWasExpected = OriginallyMeantToBeLeft,
+                |#  sensitiveException = com.fasterxml.jackson.core.JsonParseException: Unrecognized token 'TEXT': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')
+                |#   at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 5]
+                |)""".stripMargin
             )
 
             allCapturedLogs shouldBe List(
               "ERROR" ->
                 s"""HTTP body is not JSON in received HTTP response. Originally expected to turn response into a Left.
-                   |Returning: [DEEMED SAFE BY TEST LOGIC] <ResponseBodyNotJson(
-                   |#  sourceClass = class java.lang.Thread,
-                   |#  responseContext = RESPONSE TO: MYMETHOD some/url
-                   |#  ===
-                   |#  HTTP 211 Custom Status
-                   |#
-                   |#  TEXT
-                   |#  ===,
-                   |#  whichEitherWasExpected = OriginallyMeantToBeLeft,
-                   |#  sensitiveException = com.fasterxml.jackson.core.JsonParseException: Unrecognized token 'TEXT': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')
-                   |#   at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 5]
-                   |)> .
-                   |Request made for received HTTP response: MYMETHOD some/url .
-                   |Received HTTP response status: 211.
-                   |Received HTTP response body not logged for 2xx statuses.""".stripMargin
+                  |Returning: [DEEMED SAFE BY TEST LOGIC] <ResponseBodyNotJson(
+                  |#  sourceClass = class java.lang.Thread,
+                  |#  responseContext = RESPONSE TO: MYMETHOD some/url
+                  |#  ===
+                  |#  HTTP 211 Custom Status
+                  |#
+                  |#  TEXT
+                  |#  ===,
+                  |#  whichEitherWasExpected = OriginallyMeantToBeLeft,
+                  |#  sensitiveException = com.fasterxml.jackson.core.JsonParseException: Unrecognized token 'TEXT': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')
+                  |#   at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 5]
+                  |)> .
+                  |Request made for received HTTP response: MYMETHOD some/url .
+                  |Received HTTP response status: 211.
+                  |Received HTTP response body not logged for 2xx statuses.""".stripMargin
             )
           }
         }
@@ -1530,9 +1530,9 @@ final class HttpReadsBuilderSpec extends AnyFreeSpec with MockFactory {
             allCapturedLogs shouldBe List(
               "WARN" ->
                 s"""Valid and expected error response was received from HTTP call.
-                   |Request made for received HTTP response: MYMETHOD some/url .
-                   |Received HTTP response status: 277.
-                   |Received HTTP response body not logged for 2xx statuses.""".stripMargin
+                  |Request made for received HTTP response: MYMETHOD some/url .
+                  |Received HTTP response status: 277.
+                  |Received HTTP response body not logged for 2xx statuses.""".stripMargin
             )
           }
         }
@@ -1560,19 +1560,19 @@ final class HttpReadsBuilderSpec extends AnyFreeSpec with MockFactory {
             allCapturedLogs shouldBe List(
               "ERROR" ->
                 s"""Body of received HTTP response is not empty. Originally expected to turn response into a Left.
-                   |Returning: [DEEMED SAFE BY TEST LOGIC] <ResponseBodyNotEmpty(
-                   |#  sourceClass = class java.lang.Thread,
-                   |#  responseContext = RESPONSE TO: MYMETHOD some/url
-                   |#  ===
-                   |#  HTTP 277 Custom Status
-                   |#
-                   |#  {}
-                   |#  ===,
-                   |#  whichEitherWasExpected = OriginallyMeantToBeLeft
-                   |)> .
-                   |Request made for received HTTP response: MYMETHOD some/url .
-                   |Received HTTP response status: 277.
-                   |Received HTTP response body not logged for 2xx statuses.""".stripMargin
+                  |Returning: [DEEMED SAFE BY TEST LOGIC] <ResponseBodyNotEmpty(
+                  |#  sourceClass = class java.lang.Thread,
+                  |#  responseContext = RESPONSE TO: MYMETHOD some/url
+                  |#  ===
+                  |#  HTTP 277 Custom Status
+                  |#
+                  |#  {}
+                  |#  ===,
+                  |#  whichEitherWasExpected = OriginallyMeantToBeLeft
+                  |)> .
+                  |Request made for received HTTP response: MYMETHOD some/url .
+                  |Received HTTP response status: 277.
+                  |Received HTTP response body not logged for 2xx statuses.""".stripMargin
             )
           }
         }
@@ -1601,19 +1601,19 @@ final class HttpReadsBuilderSpec extends AnyFreeSpec with MockFactory {
             allCapturedLogs shouldBe List(
               "ERROR" ->
                 s"""Body of received HTTP response is not empty. Originally expected to turn response into a Left.
-                   |Returning: [DEEMED SAFE BY TEST LOGIC] <ResponseBodyNotEmpty(
-                   |#  sourceClass = class java.lang.Thread,
-                   |#  responseContext = RESPONSE TO: MYMETHOD some/url
-                   |#  ===
-                   |#  HTTP 277 Custom Status
-                   |#
-                   |#  TEXT
-                   |#  ===,
-                   |#  whichEitherWasExpected = OriginallyMeantToBeLeft
-                   |)> .
-                   |Request made for received HTTP response: MYMETHOD some/url .
-                   |Received HTTP response status: 277.
-                   |Received HTTP response body not logged for 2xx statuses.""".stripMargin
+                  |Returning: [DEEMED SAFE BY TEST LOGIC] <ResponseBodyNotEmpty(
+                  |#  sourceClass = class java.lang.Thread,
+                  |#  responseContext = RESPONSE TO: MYMETHOD some/url
+                  |#  ===
+                  |#  HTTP 277 Custom Status
+                  |#
+                  |#  TEXT
+                  |#  ===,
+                  |#  whichEitherWasExpected = OriginallyMeantToBeLeft
+                  |)> .
+                  |Request made for received HTTP response: MYMETHOD some/url .
+                  |Received HTTP response status: 277.
+                  |Received HTTP response body not logged for 2xx statuses.""".stripMargin
             )
           }
         }
@@ -1639,9 +1639,9 @@ final class HttpReadsBuilderSpec extends AnyFreeSpec with MockFactory {
             allCapturedLogs shouldBe List(
               "WARN" ->
                 s"""Valid and expected error response was received from HTTP call.
-                   |Request made for received HTTP response: MYMETHOD some/url .
-                   |Received HTTP response status: 477.
-                   |Received HTTP response body: ${Err477NoBody.Singleton.exampleBody: String}""".stripMargin
+                  |Request made for received HTTP response: MYMETHOD some/url .
+                  |Received HTTP response status: 477.
+                  |Received HTTP response body: ${Err477NoBody.Singleton.exampleBody: String}""".stripMargin
             )
           }
         }
@@ -1668,19 +1668,19 @@ final class HttpReadsBuilderSpec extends AnyFreeSpec with MockFactory {
             allCapturedLogs shouldBe List(
               "ERROR" ->
                 s"""Body of received HTTP response is not empty. Originally expected to turn response into a Left.
-                   |Returning: [DEEMED SAFE BY TEST LOGIC] <ResponseBodyNotEmpty(
-                   |#  sourceClass = class java.lang.Thread,
-                   |#  responseContext = RESPONSE TO: MYMETHOD some/url
-                   |#  ===
-                   |#  HTTP 477 Custom Status
-                   |#
-                   |#  {}
-                   |#  ===,
-                   |#  whichEitherWasExpected = OriginallyMeantToBeLeft
-                   |)> .
-                   |Request made for received HTTP response: MYMETHOD some/url .
-                   |Received HTTP response status: 477.
-                   |Received HTTP response body: {}""".stripMargin
+                  |Returning: [DEEMED SAFE BY TEST LOGIC] <ResponseBodyNotEmpty(
+                  |#  sourceClass = class java.lang.Thread,
+                  |#  responseContext = RESPONSE TO: MYMETHOD some/url
+                  |#  ===
+                  |#  HTTP 477 Custom Status
+                  |#
+                  |#  {}
+                  |#  ===,
+                  |#  whichEitherWasExpected = OriginallyMeantToBeLeft
+                  |)> .
+                  |Request made for received HTTP response: MYMETHOD some/url .
+                  |Received HTTP response status: 477.
+                  |Received HTTP response body: {}""".stripMargin
             )
           }
         }
@@ -1708,19 +1708,19 @@ final class HttpReadsBuilderSpec extends AnyFreeSpec with MockFactory {
             allCapturedLogs shouldBe List(
               "ERROR" ->
                 s"""Body of received HTTP response is not empty. Originally expected to turn response into a Left.
-                   |Returning: [DEEMED SAFE BY TEST LOGIC] <ResponseBodyNotEmpty(
-                   |#  sourceClass = class java.lang.Thread,
-                   |#  responseContext = RESPONSE TO: MYMETHOD some/url
-                   |#  ===
-                   |#  HTTP 477 Custom Status
-                   |#
-                   |#  TEXT
-                   |#  ===,
-                   |#  whichEitherWasExpected = OriginallyMeantToBeLeft
-                   |)> .
-                   |Request made for received HTTP response: MYMETHOD some/url .
-                   |Received HTTP response status: 477.
-                   |Received HTTP response body: TEXT""".stripMargin
+                  |Returning: [DEEMED SAFE BY TEST LOGIC] <ResponseBodyNotEmpty(
+                  |#  sourceClass = class java.lang.Thread,
+                  |#  responseContext = RESPONSE TO: MYMETHOD some/url
+                  |#  ===
+                  |#  HTTP 477 Custom Status
+                  |#
+                  |#  TEXT
+                  |#  ===,
+                  |#  whichEitherWasExpected = OriginallyMeantToBeLeft
+                  |)> .
+                  |Request made for received HTTP response: MYMETHOD some/url .
+                  |Received HTTP response status: 477.
+                  |Received HTTP response body: TEXT""".stripMargin
             )
           }
         }
@@ -1743,31 +1743,31 @@ final class HttpReadsBuilderSpec extends AnyFreeSpec with MockFactory {
 
                 result shouldBe Left(
                   s"""UnexpectedStatusCode(
-                     |#  sourceClass = class java.lang.Thread,
-                     |#  responseContext = RESPONSE TO: MYMETHOD some/url
-                     |#  ===
-                     |#  HTTP ${statusString(unexpected2xxStatus): String}
-                     |#
-                     |#  {"for236":true}
-                     |#  ===
-                     |)""".stripMargin
+                    |#  sourceClass = class java.lang.Thread,
+                    |#  responseContext = RESPONSE TO: MYMETHOD some/url
+                    |#  ===
+                    |#  HTTP ${statusString(unexpected2xxStatus): String}
+                    |#
+                    |#  {"for236":true}
+                    |#  ===
+                    |)""".stripMargin
                 )
 
                 allCapturedLogs shouldBe List(
                   "ERROR" ->
                     s"""HTTP status is unexpected in received HTTP response. Originally expected to turn response into a Left.
-                       |Returning: [DEEMED SAFE BY TEST LOGIC] <UnexpectedStatusCode(
-                       |#  sourceClass = class java.lang.Thread,
-                       |#  responseContext = RESPONSE TO: MYMETHOD some/url
-                       |#  ===
-                       |#  HTTP ${statusString(unexpected2xxStatus): String}
-                       |#
-                       |#  {"for236":true}
-                       |#  ===
-                       |)> .
-                       |Request made for received HTTP response: MYMETHOD some/url .
-                       |Received HTTP response status: ${unexpected2xxStatus: Int}.
-                       |Received HTTP response body not logged for 2xx statuses.""".stripMargin
+                      |Returning: [DEEMED SAFE BY TEST LOGIC] <UnexpectedStatusCode(
+                      |#  sourceClass = class java.lang.Thread,
+                      |#  responseContext = RESPONSE TO: MYMETHOD some/url
+                      |#  ===
+                      |#  HTTP ${statusString(unexpected2xxStatus): String}
+                      |#
+                      |#  {"for236":true}
+                      |#  ===
+                      |)> .
+                      |Request made for received HTTP response: MYMETHOD some/url .
+                      |Received HTTP response status: ${unexpected2xxStatus: Int}.
+                      |Received HTTP response body not logged for 2xx statuses.""".stripMargin
                 )
               }
 
@@ -1780,14 +1780,14 @@ final class HttpReadsBuilderSpec extends AnyFreeSpec with MockFactory {
 
                 result shouldBe Left(
                   s"""UnexpectedStatusCode(
-                     |#  sourceClass = class java.lang.Thread,
-                     |#  responseContext = RESPONSE TO: MYMETHOD some/url
-                     |#  ===
-                     |#  HTTP ${statusString(unexpected2xxStatus): String}
-                     |#
-                     |#  {"for236":true}
-                     |#  ===
-                     |)""".stripMargin
+                    |#  sourceClass = class java.lang.Thread,
+                    |#  responseContext = RESPONSE TO: MYMETHOD some/url
+                    |#  ===
+                    |#  HTTP ${statusString(unexpected2xxStatus): String}
+                    |#
+                    |#  {"for236":true}
+                    |#  ===
+                    |)""".stripMargin
                 )
 
                 allCapturedLogs shouldBe Nil
@@ -1809,31 +1809,31 @@ final class HttpReadsBuilderSpec extends AnyFreeSpec with MockFactory {
 
                 result shouldBe Left(
                   s"""UnexpectedStatusCode(
-                     |#  sourceClass = class java.lang.Thread,
-                     |#  responseContext = RESPONSE TO: MYMETHOD some/url
-                     |#  ===
-                     |#  HTTP ${statusString(unexpected2xxStatus): String}
-                     |#
-                     |#  {"for419":true}
-                     |#  ===
-                     |)""".stripMargin
+                    |#  sourceClass = class java.lang.Thread,
+                    |#  responseContext = RESPONSE TO: MYMETHOD some/url
+                    |#  ===
+                    |#  HTTP ${statusString(unexpected2xxStatus): String}
+                    |#
+                    |#  {"for419":true}
+                    |#  ===
+                    |)""".stripMargin
                 )
 
                 allCapturedLogs shouldBe List(
                   "ERROR" ->
                     s"""HTTP status is unexpected in received HTTP response. Originally expected to turn response into a Left.
-                       |Returning: [DEEMED SAFE BY TEST LOGIC] <UnexpectedStatusCode(
-                       |#  sourceClass = class java.lang.Thread,
-                       |#  responseContext = RESPONSE TO: MYMETHOD some/url
-                       |#  ===
-                       |#  HTTP ${statusString(unexpected2xxStatus): String}
-                       |#
-                       |#  {"for419":true}
-                       |#  ===
-                       |)> .
-                       |Request made for received HTTP response: MYMETHOD some/url .
-                       |Received HTTP response status: ${unexpected2xxStatus: Int}.
-                       |Received HTTP response body not logged for 2xx statuses.""".stripMargin
+                      |Returning: [DEEMED SAFE BY TEST LOGIC] <UnexpectedStatusCode(
+                      |#  sourceClass = class java.lang.Thread,
+                      |#  responseContext = RESPONSE TO: MYMETHOD some/url
+                      |#  ===
+                      |#  HTTP ${statusString(unexpected2xxStatus): String}
+                      |#
+                      |#  {"for419":true}
+                      |#  ===
+                      |)> .
+                      |Request made for received HTTP response: MYMETHOD some/url .
+                      |Received HTTP response status: ${unexpected2xxStatus: Int}.
+                      |Received HTTP response body not logged for 2xx statuses.""".stripMargin
                 )
               }
 
@@ -1846,14 +1846,14 @@ final class HttpReadsBuilderSpec extends AnyFreeSpec with MockFactory {
 
                 result shouldBe Left(
                   s"""UnexpectedStatusCode(
-                     |#  sourceClass = class java.lang.Thread,
-                     |#  responseContext = RESPONSE TO: MYMETHOD some/url
-                     |#  ===
-                     |#  HTTP ${statusString(unexpected2xxStatus): String}
-                     |#
-                     |#  {"for419":true}
-                     |#  ===
-                     |)""".stripMargin
+                    |#  sourceClass = class java.lang.Thread,
+                    |#  responseContext = RESPONSE TO: MYMETHOD some/url
+                    |#  ===
+                    |#  HTTP ${statusString(unexpected2xxStatus): String}
+                    |#
+                    |#  {"for419":true}
+                    |#  ===
+                    |)""".stripMargin
                 )
 
                 allCapturedLogs shouldBe Nil
@@ -1875,31 +1875,31 @@ final class HttpReadsBuilderSpec extends AnyFreeSpec with MockFactory {
 
                 result shouldBe Left(
                   s"""UnexpectedStatusCode(
-                     |#  sourceClass = class java.lang.Thread,
-                     |#  responseContext = RESPONSE TO: MYMETHOD some/url
-                     |#  ===
-                     |#  HTTP ${statusString(unexpected2xxStatus): String}
-                     |#
-                     |#  {"for109":"example"}
-                     |#  ===
-                     |)""".stripMargin
+                    |#  sourceClass = class java.lang.Thread,
+                    |#  responseContext = RESPONSE TO: MYMETHOD some/url
+                    |#  ===
+                    |#  HTTP ${statusString(unexpected2xxStatus): String}
+                    |#
+                    |#  {"for109":"example"}
+                    |#  ===
+                    |)""".stripMargin
                 )
 
                 allCapturedLogs shouldBe List(
                   "ERROR" ->
                     s"""HTTP status is unexpected in received HTTP response. Originally expected to turn response into a Left.
-                       |Returning: [DEEMED SAFE BY TEST LOGIC] <UnexpectedStatusCode(
-                       |#  sourceClass = class java.lang.Thread,
-                       |#  responseContext = RESPONSE TO: MYMETHOD some/url
-                       |#  ===
-                       |#  HTTP ${statusString(unexpected2xxStatus): String}
-                       |#
-                       |#  {"for109":"example"}
-                       |#  ===
-                       |)> .
-                       |Request made for received HTTP response: MYMETHOD some/url .
-                       |Received HTTP response status: ${unexpected2xxStatus: Int}.
-                       |Received HTTP response body not logged for 2xx statuses.""".stripMargin
+                      |Returning: [DEEMED SAFE BY TEST LOGIC] <UnexpectedStatusCode(
+                      |#  sourceClass = class java.lang.Thread,
+                      |#  responseContext = RESPONSE TO: MYMETHOD some/url
+                      |#  ===
+                      |#  HTTP ${statusString(unexpected2xxStatus): String}
+                      |#
+                      |#  {"for109":"example"}
+                      |#  ===
+                      |)> .
+                      |Request made for received HTTP response: MYMETHOD some/url .
+                      |Received HTTP response status: ${unexpected2xxStatus: Int}.
+                      |Received HTTP response body not logged for 2xx statuses.""".stripMargin
                 )
               }
 
@@ -1912,14 +1912,14 @@ final class HttpReadsBuilderSpec extends AnyFreeSpec with MockFactory {
 
                 result shouldBe Left(
                   s"""UnexpectedStatusCode(
-                     |#  sourceClass = class java.lang.Thread,
-                     |#  responseContext = RESPONSE TO: MYMETHOD some/url
-                     |#  ===
-                     |#  HTTP ${statusString(unexpected2xxStatus): String}
-                     |#
-                     |#  {"for109":"example"}
-                     |#  ===
-                     |)""".stripMargin
+                    |#  sourceClass = class java.lang.Thread,
+                    |#  responseContext = RESPONSE TO: MYMETHOD some/url
+                    |#  ===
+                    |#  HTTP ${statusString(unexpected2xxStatus): String}
+                    |#
+                    |#  {"for109":"example"}
+                    |#  ===
+                    |)""".stripMargin
                 )
 
                 allCapturedLogs shouldBe Nil
@@ -1945,31 +1945,31 @@ final class HttpReadsBuilderSpec extends AnyFreeSpec with MockFactory {
 
                 result shouldBe Left(
                   s"""UnexpectedStatusCode(
-                     |#  sourceClass = class java.lang.Thread,
-                     |#  responseContext = RESPONSE TO: MYMETHOD some/url
-                     |#  ===
-                     |#  HTTP ${statusString(unexpected2xxStatus): String}
-                     |#
-                     |#  {"for211":"example"}
-                     |#  ===
-                     |)""".stripMargin
+                    |#  sourceClass = class java.lang.Thread,
+                    |#  responseContext = RESPONSE TO: MYMETHOD some/url
+                    |#  ===
+                    |#  HTTP ${statusString(unexpected2xxStatus): String}
+                    |#
+                    |#  {"for211":"example"}
+                    |#  ===
+                    |)""".stripMargin
                 )
 
                 allCapturedLogs shouldBe List(
                   "ERROR" ->
                     s"""HTTP status is unexpected in received HTTP response. Originally expected to turn response into a Left.
-                       |Returning: [DEEMED SAFE BY TEST LOGIC] <UnexpectedStatusCode(
-                       |#  sourceClass = class java.lang.Thread,
-                       |#  responseContext = RESPONSE TO: MYMETHOD some/url
-                       |#  ===
-                       |#  HTTP ${statusString(unexpected2xxStatus): String}
-                       |#
-                       |#  {"for211":"example"}
-                       |#  ===
-                       |)> .
-                       |Request made for received HTTP response: MYMETHOD some/url .
-                       |Received HTTP response status: ${unexpected2xxStatus: Int}.
-                       |Received HTTP response body not logged for 2xx statuses.""".stripMargin
+                      |Returning: [DEEMED SAFE BY TEST LOGIC] <UnexpectedStatusCode(
+                      |#  sourceClass = class java.lang.Thread,
+                      |#  responseContext = RESPONSE TO: MYMETHOD some/url
+                      |#  ===
+                      |#  HTTP ${statusString(unexpected2xxStatus): String}
+                      |#
+                      |#  {"for211":"example"}
+                      |#  ===
+                      |)> .
+                      |Request made for received HTTP response: MYMETHOD some/url .
+                      |Received HTTP response status: ${unexpected2xxStatus: Int}.
+                      |Received HTTP response body not logged for 2xx statuses.""".stripMargin
                 )
               }
 
@@ -1986,14 +1986,14 @@ final class HttpReadsBuilderSpec extends AnyFreeSpec with MockFactory {
 
                 result shouldBe Left(
                   s"""UnexpectedStatusCode(
-                     |#  sourceClass = class java.lang.Thread,
-                     |#  responseContext = RESPONSE TO: MYMETHOD some/url
-                     |#  ===
-                     |#  HTTP ${statusString(unexpected2xxStatus): String}
-                     |#
-                     |#  {"for211":"example"}
-                     |#  ===
-                     |)""".stripMargin
+                    |#  sourceClass = class java.lang.Thread,
+                    |#  responseContext = RESPONSE TO: MYMETHOD some/url
+                    |#  ===
+                    |#  HTTP ${statusString(unexpected2xxStatus): String}
+                    |#
+                    |#  {"for211":"example"}
+                    |#  ===
+                    |)""".stripMargin
                 )
 
                 allCapturedLogs shouldBe Nil
@@ -2013,31 +2013,31 @@ final class HttpReadsBuilderSpec extends AnyFreeSpec with MockFactory {
 
                 result shouldBe Left(
                   s"""UnexpectedStatusCode(
-                     |#  sourceClass = class java.lang.Thread,
-                     |#  responseContext = RESPONSE TO: MYMETHOD some/url
-                     |#  ===
-                     |#  HTTP ${statusString(unexpected2xxStatus): String}
-                     |#
-                     |#  {}
-                     |#  ===
-                     |)""".stripMargin
+                    |#  sourceClass = class java.lang.Thread,
+                    |#  responseContext = RESPONSE TO: MYMETHOD some/url
+                    |#  ===
+                    |#  HTTP ${statusString(unexpected2xxStatus): String}
+                    |#
+                    |#  {}
+                    |#  ===
+                    |)""".stripMargin
                 )
 
                 allCapturedLogs shouldBe List(
                   "ERROR" ->
                     s"""HTTP status is unexpected in received HTTP response. Originally expected to turn response into a Left.
-                       |Returning: [DEEMED SAFE BY TEST LOGIC] <UnexpectedStatusCode(
-                       |#  sourceClass = class java.lang.Thread,
-                       |#  responseContext = RESPONSE TO: MYMETHOD some/url
-                       |#  ===
-                       |#  HTTP ${statusString(unexpected2xxStatus): String}
-                       |#
-                       |#  {}
-                       |#  ===
-                       |)> .
-                       |Request made for received HTTP response: MYMETHOD some/url .
-                       |Received HTTP response status: ${unexpected2xxStatus: Int}.
-                       |Received HTTP response body not logged for 2xx statuses.""".stripMargin
+                      |Returning: [DEEMED SAFE BY TEST LOGIC] <UnexpectedStatusCode(
+                      |#  sourceClass = class java.lang.Thread,
+                      |#  responseContext = RESPONSE TO: MYMETHOD some/url
+                      |#  ===
+                      |#  HTTP ${statusString(unexpected2xxStatus): String}
+                      |#
+                      |#  {}
+                      |#  ===
+                      |)> .
+                      |Request made for received HTTP response: MYMETHOD some/url .
+                      |Received HTTP response status: ${unexpected2xxStatus: Int}.
+                      |Received HTTP response body not logged for 2xx statuses.""".stripMargin
                 )
               }
 
@@ -2050,14 +2050,14 @@ final class HttpReadsBuilderSpec extends AnyFreeSpec with MockFactory {
 
                 result shouldBe Left(
                   s"""UnexpectedStatusCode(
-                     |#  sourceClass = class java.lang.Thread,
-                     |#  responseContext = RESPONSE TO: MYMETHOD some/url
-                     |#  ===
-                     |#  HTTP ${statusString(unexpected2xxStatus): String}
-                     |#
-                     |#  {}
-                     |#  ===
-                     |)""".stripMargin
+                    |#  sourceClass = class java.lang.Thread,
+                    |#  responseContext = RESPONSE TO: MYMETHOD some/url
+                    |#  ===
+                    |#  HTTP ${statusString(unexpected2xxStatus): String}
+                    |#
+                    |#  {}
+                    |#  ===
+                    |)""".stripMargin
                 )
 
                 allCapturedLogs shouldBe Nil
@@ -2077,31 +2077,31 @@ final class HttpReadsBuilderSpec extends AnyFreeSpec with MockFactory {
 
                 result shouldBe Left(
                   s"""UnexpectedStatusCode(
-                     |#  sourceClass = class java.lang.Thread,
-                     |#  responseContext = RESPONSE TO: MYMETHOD some/url
-                     |#  ===
-                     |#  HTTP ${statusString(unexpected2xxStatus): String}
-                     |#
-                     |#  SOMETEXT
-                     |#  ===
-                     |)""".stripMargin
+                    |#  sourceClass = class java.lang.Thread,
+                    |#  responseContext = RESPONSE TO: MYMETHOD some/url
+                    |#  ===
+                    |#  HTTP ${statusString(unexpected2xxStatus): String}
+                    |#
+                    |#  SOMETEXT
+                    |#  ===
+                    |)""".stripMargin
                 )
 
                 allCapturedLogs shouldBe List(
                   "ERROR" ->
                     s"""HTTP status is unexpected in received HTTP response. Originally expected to turn response into a Left.
-                       |Returning: [DEEMED SAFE BY TEST LOGIC] <UnexpectedStatusCode(
-                       |#  sourceClass = class java.lang.Thread,
-                       |#  responseContext = RESPONSE TO: MYMETHOD some/url
-                       |#  ===
-                       |#  HTTP ${statusString(unexpected2xxStatus): String}
-                       |#
-                       |#  SOMETEXT
-                       |#  ===
-                       |)> .
-                       |Request made for received HTTP response: MYMETHOD some/url .
-                       |Received HTTP response status: ${unexpected2xxStatus: Int}.
-                       |Received HTTP response body not logged for 2xx statuses.""".stripMargin
+                      |Returning: [DEEMED SAFE BY TEST LOGIC] <UnexpectedStatusCode(
+                      |#  sourceClass = class java.lang.Thread,
+                      |#  responseContext = RESPONSE TO: MYMETHOD some/url
+                      |#  ===
+                      |#  HTTP ${statusString(unexpected2xxStatus): String}
+                      |#
+                      |#  SOMETEXT
+                      |#  ===
+                      |)> .
+                      |Request made for received HTTP response: MYMETHOD some/url .
+                      |Received HTTP response status: ${unexpected2xxStatus: Int}.
+                      |Received HTTP response body not logged for 2xx statuses.""".stripMargin
                 )
               }
 
@@ -2114,14 +2114,14 @@ final class HttpReadsBuilderSpec extends AnyFreeSpec with MockFactory {
 
                 result shouldBe Left(
                   s"""UnexpectedStatusCode(
-                     |#  sourceClass = class java.lang.Thread,
-                     |#  responseContext = RESPONSE TO: MYMETHOD some/url
-                     |#  ===
-                     |#  HTTP ${statusString(unexpected2xxStatus): String}
-                     |#
-                     |#  SOMETEXT
-                     |#  ===
-                     |)""".stripMargin
+                    |#  sourceClass = class java.lang.Thread,
+                    |#  responseContext = RESPONSE TO: MYMETHOD some/url
+                    |#  ===
+                    |#  HTTP ${statusString(unexpected2xxStatus): String}
+                    |#
+                    |#  SOMETEXT
+                    |#  ===
+                    |)""".stripMargin
                 )
 
                 allCapturedLogs shouldBe Nil
@@ -2148,31 +2148,31 @@ final class HttpReadsBuilderSpec extends AnyFreeSpec with MockFactory {
 
                 result shouldBe Left(
                   s"""UnexpectedStatusCode(
-                     |#  sourceClass = class java.lang.Thread,
-                     |#  responseContext = RESPONSE TO: MYMETHOD some/url
-                     |#  ===
-                     |#  HTTP ${statusString(unexpectedNon2xxStatus): String}
-                     |#
-                     |#  {"for236":true}
-                     |#  ===
-                     |)""".stripMargin
+                    |#  sourceClass = class java.lang.Thread,
+                    |#  responseContext = RESPONSE TO: MYMETHOD some/url
+                    |#  ===
+                    |#  HTTP ${statusString(unexpectedNon2xxStatus): String}
+                    |#
+                    |#  {"for236":true}
+                    |#  ===
+                    |)""".stripMargin
                 )
 
                 allCapturedLogs shouldBe List(
                   "ERROR" ->
                     s"""HTTP status is unexpected in received HTTP response. Originally expected to turn response into a Left.
-                       |Returning: [DEEMED SAFE BY TEST LOGIC] <UnexpectedStatusCode(
-                       |#  sourceClass = class java.lang.Thread,
-                       |#  responseContext = RESPONSE TO: MYMETHOD some/url
-                       |#  ===
-                       |#  HTTP ${statusString(unexpectedNon2xxStatus): String}
-                       |#
-                       |#  {"for236":true}
-                       |#  ===
-                       |)> .
-                       |Request made for received HTTP response: MYMETHOD some/url .
-                       |Received HTTP response status: ${unexpectedNon2xxStatus: Int}.
-                       |Received HTTP response body: ${Succ236Json.Wrapper.exampleBody: String}""".stripMargin
+                      |Returning: [DEEMED SAFE BY TEST LOGIC] <UnexpectedStatusCode(
+                      |#  sourceClass = class java.lang.Thread,
+                      |#  responseContext = RESPONSE TO: MYMETHOD some/url
+                      |#  ===
+                      |#  HTTP ${statusString(unexpectedNon2xxStatus): String}
+                      |#
+                      |#  {"for236":true}
+                      |#  ===
+                      |)> .
+                      |Request made for received HTTP response: MYMETHOD some/url .
+                      |Received HTTP response status: ${unexpectedNon2xxStatus: Int}.
+                      |Received HTTP response body: ${Succ236Json.Wrapper.exampleBody: String}""".stripMargin
                 )
               }
 
@@ -2185,14 +2185,14 @@ final class HttpReadsBuilderSpec extends AnyFreeSpec with MockFactory {
 
                 result shouldBe Left(
                   s"""UnexpectedStatusCode(
-                     |#  sourceClass = class java.lang.Thread,
-                     |#  responseContext = RESPONSE TO: MYMETHOD some/url
-                     |#  ===
-                     |#  HTTP ${statusString(unexpectedNon2xxStatus): String}
-                     |#
-                     |#  {"for236":true}
-                     |#  ===
-                     |)""".stripMargin
+                    |#  sourceClass = class java.lang.Thread,
+                    |#  responseContext = RESPONSE TO: MYMETHOD some/url
+                    |#  ===
+                    |#  HTTP ${statusString(unexpectedNon2xxStatus): String}
+                    |#
+                    |#  {"for236":true}
+                    |#  ===
+                    |)""".stripMargin
                 )
 
                 allCapturedLogs shouldBe Nil
@@ -2214,31 +2214,31 @@ final class HttpReadsBuilderSpec extends AnyFreeSpec with MockFactory {
 
                 result shouldBe Left(
                   s"""UnexpectedStatusCode(
-                     |#  sourceClass = class java.lang.Thread,
-                     |#  responseContext = RESPONSE TO: MYMETHOD some/url
-                     |#  ===
-                     |#  HTTP ${statusString(unexpectedNon2xxStatus): String}
-                     |#
-                     |#  {"for419":true}
-                     |#  ===
-                     |)""".stripMargin
+                    |#  sourceClass = class java.lang.Thread,
+                    |#  responseContext = RESPONSE TO: MYMETHOD some/url
+                    |#  ===
+                    |#  HTTP ${statusString(unexpectedNon2xxStatus): String}
+                    |#
+                    |#  {"for419":true}
+                    |#  ===
+                    |)""".stripMargin
                 )
 
                 allCapturedLogs shouldBe List(
                   "ERROR" ->
                     s"""HTTP status is unexpected in received HTTP response. Originally expected to turn response into a Left.
-                       |Returning: [DEEMED SAFE BY TEST LOGIC] <UnexpectedStatusCode(
-                       |#  sourceClass = class java.lang.Thread,
-                       |#  responseContext = RESPONSE TO: MYMETHOD some/url
-                       |#  ===
-                       |#  HTTP ${statusString(unexpectedNon2xxStatus): String}
-                       |#
-                       |#  {"for419":true}
-                       |#  ===
-                       |)> .
-                       |Request made for received HTTP response: MYMETHOD some/url .
-                       |Received HTTP response status: ${unexpectedNon2xxStatus: Int}.
-                       |Received HTTP response body: ${Succ419Json.Wrapper.exampleBody: String}""".stripMargin
+                      |Returning: [DEEMED SAFE BY TEST LOGIC] <UnexpectedStatusCode(
+                      |#  sourceClass = class java.lang.Thread,
+                      |#  responseContext = RESPONSE TO: MYMETHOD some/url
+                      |#  ===
+                      |#  HTTP ${statusString(unexpectedNon2xxStatus): String}
+                      |#
+                      |#  {"for419":true}
+                      |#  ===
+                      |)> .
+                      |Request made for received HTTP response: MYMETHOD some/url .
+                      |Received HTTP response status: ${unexpectedNon2xxStatus: Int}.
+                      |Received HTTP response body: ${Succ419Json.Wrapper.exampleBody: String}""".stripMargin
                 )
               }
 
@@ -2251,14 +2251,14 @@ final class HttpReadsBuilderSpec extends AnyFreeSpec with MockFactory {
 
                 result shouldBe Left(
                   s"""UnexpectedStatusCode(
-                     |#  sourceClass = class java.lang.Thread,
-                     |#  responseContext = RESPONSE TO: MYMETHOD some/url
-                     |#  ===
-                     |#  HTTP ${statusString(unexpectedNon2xxStatus): String}
-                     |#
-                     |#  {"for419":true}
-                     |#  ===
-                     |)""".stripMargin
+                    |#  sourceClass = class java.lang.Thread,
+                    |#  responseContext = RESPONSE TO: MYMETHOD some/url
+                    |#  ===
+                    |#  HTTP ${statusString(unexpectedNon2xxStatus): String}
+                    |#
+                    |#  {"for419":true}
+                    |#  ===
+                    |)""".stripMargin
                 )
 
                 allCapturedLogs shouldBe Nil
@@ -2280,31 +2280,31 @@ final class HttpReadsBuilderSpec extends AnyFreeSpec with MockFactory {
 
                 result shouldBe Left(
                   s"""UnexpectedStatusCode(
-                     |#  sourceClass = class java.lang.Thread,
-                     |#  responseContext = RESPONSE TO: MYMETHOD some/url
-                     |#  ===
-                     |#  HTTP ${statusString(unexpectedNon2xxStatus): String}
-                     |#
-                     |#  {"for109":"example"}
-                     |#  ===
-                     |)""".stripMargin
+                    |#  sourceClass = class java.lang.Thread,
+                    |#  responseContext = RESPONSE TO: MYMETHOD some/url
+                    |#  ===
+                    |#  HTTP ${statusString(unexpectedNon2xxStatus): String}
+                    |#
+                    |#  {"for109":"example"}
+                    |#  ===
+                    |)""".stripMargin
                 )
 
                 allCapturedLogs shouldBe List(
                   "ERROR" ->
                     s"""HTTP status is unexpected in received HTTP response. Originally expected to turn response into a Left.
-                       |Returning: [DEEMED SAFE BY TEST LOGIC] <UnexpectedStatusCode(
-                       |#  sourceClass = class java.lang.Thread,
-                       |#  responseContext = RESPONSE TO: MYMETHOD some/url
-                       |#  ===
-                       |#  HTTP ${statusString(unexpectedNon2xxStatus): String}
-                       |#
-                       |#  {"for109":"example"}
-                       |#  ===
-                       |)> .
-                       |Request made for received HTTP response: MYMETHOD some/url .
-                       |Received HTTP response status: ${unexpectedNon2xxStatus: Int}.
-                       |Received HTTP response body: ${Err109Json.Wrapper.exampleBody: String}""".stripMargin
+                      |Returning: [DEEMED SAFE BY TEST LOGIC] <UnexpectedStatusCode(
+                      |#  sourceClass = class java.lang.Thread,
+                      |#  responseContext = RESPONSE TO: MYMETHOD some/url
+                      |#  ===
+                      |#  HTTP ${statusString(unexpectedNon2xxStatus): String}
+                      |#
+                      |#  {"for109":"example"}
+                      |#  ===
+                      |)> .
+                      |Request made for received HTTP response: MYMETHOD some/url .
+                      |Received HTTP response status: ${unexpectedNon2xxStatus: Int}.
+                      |Received HTTP response body: ${Err109Json.Wrapper.exampleBody: String}""".stripMargin
                 )
               }
 
@@ -2317,14 +2317,14 @@ final class HttpReadsBuilderSpec extends AnyFreeSpec with MockFactory {
 
                 result shouldBe Left(
                   s"""UnexpectedStatusCode(
-                     |#  sourceClass = class java.lang.Thread,
-                     |#  responseContext = RESPONSE TO: MYMETHOD some/url
-                     |#  ===
-                     |#  HTTP ${statusString(unexpectedNon2xxStatus): String}
-                     |#
-                     |#  {"for109":"example"}
-                     |#  ===
-                     |)""".stripMargin
+                    |#  sourceClass = class java.lang.Thread,
+                    |#  responseContext = RESPONSE TO: MYMETHOD some/url
+                    |#  ===
+                    |#  HTTP ${statusString(unexpectedNon2xxStatus): String}
+                    |#
+                    |#  {"for109":"example"}
+                    |#  ===
+                    |)""".stripMargin
                 )
 
                 allCapturedLogs shouldBe Nil
@@ -2350,31 +2350,31 @@ final class HttpReadsBuilderSpec extends AnyFreeSpec with MockFactory {
 
                 result shouldBe Left(
                   s"""UnexpectedStatusCode(
-                     |#  sourceClass = class java.lang.Thread,
-                     |#  responseContext = RESPONSE TO: MYMETHOD some/url
-                     |#  ===
-                     |#  HTTP ${statusString(unexpectedNon2xxStatus): String}
-                     |#
-                     |#  {"for211":"example"}
-                     |#  ===
-                     |)""".stripMargin
+                    |#  sourceClass = class java.lang.Thread,
+                    |#  responseContext = RESPONSE TO: MYMETHOD some/url
+                    |#  ===
+                    |#  HTTP ${statusString(unexpectedNon2xxStatus): String}
+                    |#
+                    |#  {"for211":"example"}
+                    |#  ===
+                    |)""".stripMargin
                 )
 
                 allCapturedLogs shouldBe List(
                   "ERROR" ->
                     s"""HTTP status is unexpected in received HTTP response. Originally expected to turn response into a Left.
-                       |Returning: [DEEMED SAFE BY TEST LOGIC] <UnexpectedStatusCode(
-                       |#  sourceClass = class java.lang.Thread,
-                       |#  responseContext = RESPONSE TO: MYMETHOD some/url
-                       |#  ===
-                       |#  HTTP ${statusString(unexpectedNon2xxStatus): String}
-                       |#
-                       |#  {"for211":"example"}
-                       |#  ===
-                       |)> .
-                       |Request made for received HTTP response: MYMETHOD some/url .
-                       |Received HTTP response status: ${unexpectedNon2xxStatus: Int}.
-                       |Received HTTP response body: ${Err211JsonTransf.ToTransform.exampleBody: String}""".stripMargin
+                      |Returning: [DEEMED SAFE BY TEST LOGIC] <UnexpectedStatusCode(
+                      |#  sourceClass = class java.lang.Thread,
+                      |#  responseContext = RESPONSE TO: MYMETHOD some/url
+                      |#  ===
+                      |#  HTTP ${statusString(unexpectedNon2xxStatus): String}
+                      |#
+                      |#  {"for211":"example"}
+                      |#  ===
+                      |)> .
+                      |Request made for received HTTP response: MYMETHOD some/url .
+                      |Received HTTP response status: ${unexpectedNon2xxStatus: Int}.
+                      |Received HTTP response body: ${Err211JsonTransf.ToTransform.exampleBody: String}""".stripMargin
                 )
               }
 
@@ -2391,14 +2391,14 @@ final class HttpReadsBuilderSpec extends AnyFreeSpec with MockFactory {
 
                 result shouldBe Left(
                   s"""UnexpectedStatusCode(
-                     |#  sourceClass = class java.lang.Thread,
-                     |#  responseContext = RESPONSE TO: MYMETHOD some/url
-                     |#  ===
-                     |#  HTTP ${statusString(unexpectedNon2xxStatus): String}
-                     |#
-                     |#  {"for211":"example"}
-                     |#  ===
-                     |)""".stripMargin
+                    |#  sourceClass = class java.lang.Thread,
+                    |#  responseContext = RESPONSE TO: MYMETHOD some/url
+                    |#  ===
+                    |#  HTTP ${statusString(unexpectedNon2xxStatus): String}
+                    |#
+                    |#  {"for211":"example"}
+                    |#  ===
+                    |)""".stripMargin
                 )
 
                 allCapturedLogs shouldBe Nil
@@ -2418,31 +2418,31 @@ final class HttpReadsBuilderSpec extends AnyFreeSpec with MockFactory {
 
                 result shouldBe Left(
                   s"""UnexpectedStatusCode(
-                     |#  sourceClass = class java.lang.Thread,
-                     |#  responseContext = RESPONSE TO: MYMETHOD some/url
-                     |#  ===
-                     |#  HTTP ${statusString(unexpectedNon2xxStatus): String}
-                     |#
-                     |#  {}
-                     |#  ===
-                     |)""".stripMargin
+                    |#  sourceClass = class java.lang.Thread,
+                    |#  responseContext = RESPONSE TO: MYMETHOD some/url
+                    |#  ===
+                    |#  HTTP ${statusString(unexpectedNon2xxStatus): String}
+                    |#
+                    |#  {}
+                    |#  ===
+                    |)""".stripMargin
                 )
 
                 allCapturedLogs shouldBe List(
                   "ERROR" ->
                     s"""HTTP status is unexpected in received HTTP response. Originally expected to turn response into a Left.
-                       |Returning: [DEEMED SAFE BY TEST LOGIC] <UnexpectedStatusCode(
-                       |#  sourceClass = class java.lang.Thread,
-                       |#  responseContext = RESPONSE TO: MYMETHOD some/url
-                       |#  ===
-                       |#  HTTP ${statusString(unexpectedNon2xxStatus): String}
-                       |#
-                       |#  {}
-                       |#  ===
-                       |)> .
-                       |Request made for received HTTP response: MYMETHOD some/url .
-                       |Received HTTP response status: ${unexpectedNon2xxStatus: Int}.
-                       |Received HTTP response body: {}""".stripMargin
+                      |Returning: [DEEMED SAFE BY TEST LOGIC] <UnexpectedStatusCode(
+                      |#  sourceClass = class java.lang.Thread,
+                      |#  responseContext = RESPONSE TO: MYMETHOD some/url
+                      |#  ===
+                      |#  HTTP ${statusString(unexpectedNon2xxStatus): String}
+                      |#
+                      |#  {}
+                      |#  ===
+                      |)> .
+                      |Request made for received HTTP response: MYMETHOD some/url .
+                      |Received HTTP response status: ${unexpectedNon2xxStatus: Int}.
+                      |Received HTTP response body: {}""".stripMargin
                 )
               }
 
@@ -2455,14 +2455,14 @@ final class HttpReadsBuilderSpec extends AnyFreeSpec with MockFactory {
 
                 result shouldBe Left(
                   s"""UnexpectedStatusCode(
-                     |#  sourceClass = class java.lang.Thread,
-                     |#  responseContext = RESPONSE TO: MYMETHOD some/url
-                     |#  ===
-                     |#  HTTP ${statusString(unexpectedNon2xxStatus): String}
-                     |#
-                     |#  {}
-                     |#  ===
-                     |)""".stripMargin
+                    |#  sourceClass = class java.lang.Thread,
+                    |#  responseContext = RESPONSE TO: MYMETHOD some/url
+                    |#  ===
+                    |#  HTTP ${statusString(unexpectedNon2xxStatus): String}
+                    |#
+                    |#  {}
+                    |#  ===
+                    |)""".stripMargin
                 )
 
                 allCapturedLogs shouldBe Nil
@@ -2482,31 +2482,31 @@ final class HttpReadsBuilderSpec extends AnyFreeSpec with MockFactory {
 
                 result shouldBe Left(
                   s"""UnexpectedStatusCode(
-                     |#  sourceClass = class java.lang.Thread,
-                     |#  responseContext = RESPONSE TO: MYMETHOD some/url
-                     |#  ===
-                     |#  HTTP ${statusString(unexpectedNon2xxStatus): String}
-                     |#
-                     |#  SOMETEXT
-                     |#  ===
-                     |)""".stripMargin
+                    |#  sourceClass = class java.lang.Thread,
+                    |#  responseContext = RESPONSE TO: MYMETHOD some/url
+                    |#  ===
+                    |#  HTTP ${statusString(unexpectedNon2xxStatus): String}
+                    |#
+                    |#  SOMETEXT
+                    |#  ===
+                    |)""".stripMargin
                 )
 
                 allCapturedLogs shouldBe List(
                   "ERROR" ->
                     s"""HTTP status is unexpected in received HTTP response. Originally expected to turn response into a Left.
-                       |Returning: [DEEMED SAFE BY TEST LOGIC] <UnexpectedStatusCode(
-                       |#  sourceClass = class java.lang.Thread,
-                       |#  responseContext = RESPONSE TO: MYMETHOD some/url
-                       |#  ===
-                       |#  HTTP ${statusString(unexpectedNon2xxStatus): String}
-                       |#
-                       |#  SOMETEXT
-                       |#  ===
-                       |)> .
-                       |Request made for received HTTP response: MYMETHOD some/url .
-                       |Received HTTP response status: ${unexpectedNon2xxStatus: Int}.
-                       |Received HTTP response body: SOMETEXT""".stripMargin
+                      |Returning: [DEEMED SAFE BY TEST LOGIC] <UnexpectedStatusCode(
+                      |#  sourceClass = class java.lang.Thread,
+                      |#  responseContext = RESPONSE TO: MYMETHOD some/url
+                      |#  ===
+                      |#  HTTP ${statusString(unexpectedNon2xxStatus): String}
+                      |#
+                      |#  SOMETEXT
+                      |#  ===
+                      |)> .
+                      |Request made for received HTTP response: MYMETHOD some/url .
+                      |Received HTTP response status: ${unexpectedNon2xxStatus: Int}.
+                      |Received HTTP response body: SOMETEXT""".stripMargin
                 )
               }
 
@@ -2519,14 +2519,14 @@ final class HttpReadsBuilderSpec extends AnyFreeSpec with MockFactory {
 
                 result shouldBe Left(
                   s"""UnexpectedStatusCode(
-                     |#  sourceClass = class java.lang.Thread,
-                     |#  responseContext = RESPONSE TO: MYMETHOD some/url
-                     |#  ===
-                     |#  HTTP ${statusString(unexpectedNon2xxStatus): String}
-                     |#
-                     |#  SOMETEXT
-                     |#  ===
-                     |)""".stripMargin
+                    |#  sourceClass = class java.lang.Thread,
+                    |#  responseContext = RESPONSE TO: MYMETHOD some/url
+                    |#  ===
+                    |#  HTTP ${statusString(unexpectedNon2xxStatus): String}
+                    |#
+                    |#  SOMETEXT
+                    |#  ===
+                    |)""".stripMargin
                 )
 
                 allCapturedLogs shouldBe Nil

--- a/test/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyControllerSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/controllers/TimeToPayProxyControllerSpec.scala
@@ -17,14 +17,14 @@
 package uk.gov.hmrc.timetopayproxy.controllers
 
 import cats.data.NonEmptyList
-import cats.syntax.either._
+import cats.syntax.either.*
 import org.scalamock.scalatest.MockFactory
-import org.scalatest.matchers.should.Matchers._
+import org.scalatest.matchers.should.Matchers.*
 import org.scalatest.wordspec.AnyWordSpec
 import play.api.http.{ MimeTypes, Status }
 import play.api.libs.json.{ JsArray, JsObject, JsValue, Json }
 import play.api.mvc.{ ControllerComponents, Result }
-import play.api.test.Helpers._
+import play.api.test.Helpers.*
 import play.api.test.{ FakeRequest, Helpers }
 import uk.gov.hmrc.auth.core.PlayAuthConnector
 import uk.gov.hmrc.auth.core.authorise.Predicate
@@ -34,17 +34,17 @@ import uk.gov.hmrc.timetopayproxy.actions.auth.ReadAuthoriseAction
 import uk.gov.hmrc.timetopayproxy.actions.auth.StoredEnrolmentScope.ReadTimeToPayProxy
 import uk.gov.hmrc.timetopayproxy.actions.correlationid.CorrelationIdPopulationAction
 import uk.gov.hmrc.timetopayproxy.config.FeatureSwitch
-import uk.gov.hmrc.timetopayproxy.models._
-import uk.gov.hmrc.timetopayproxy.models.affordablequotes._
+import uk.gov.hmrc.timetopayproxy.models.*
+import uk.gov.hmrc.timetopayproxy.models.affordablequotes.*
 import uk.gov.hmrc.timetopayproxy.models.currency.GbpPounds
 import uk.gov.hmrc.timetopayproxy.models.error.TtppEnvelope.TtppEnvelope
 import uk.gov.hmrc.timetopayproxy.models.error.{ ConnectorError, TtppEnvelope, TtppErrorResponse }
 import uk.gov.hmrc.timetopayproxy.models.featureSwitches.{ EnrolmentAuthEnabled, SaRelease2Enabled }
-import uk.gov.hmrc.timetopayproxy.models.saonly.chargeInfoApi._
-import uk.gov.hmrc.timetopayproxy.models.saonly.common._
+import uk.gov.hmrc.timetopayproxy.models.saonly.chargeInfoApi.*
+import uk.gov.hmrc.timetopayproxy.models.saonly.common.*
 import uk.gov.hmrc.timetopayproxy.models.saonly.common.apistatus.{ ApiName, ApiStatus, ApiStatusCode }
-import uk.gov.hmrc.timetopayproxy.models.saonly.ttpcancel._
-import uk.gov.hmrc.timetopayproxy.models.saonly.ttpfullamend._
+import uk.gov.hmrc.timetopayproxy.models.saonly.ttpcancel.*
+import uk.gov.hmrc.timetopayproxy.models.saonly.ttpfullamend.*
 import uk.gov.hmrc.timetopayproxy.models.saonly.ttpinform.{ TtpInformRequest, TtpInformSuccessfulResponse }
 import uk.gov.hmrc.timetopayproxy.services.{ TTPEService, TTPQuoteService, TtpFeedbackLoopService }
 
@@ -581,7 +581,7 @@ class TimeToPayProxyControllerSpec extends AnyWordSpec with MockFactory {
         )
       }
 
-      "when payment method is one of the supported values" in {
+      "when payment method is one of the supported values" in
         List(
           PaymentMethod.Bacs,
           PaymentMethod.BankPayments,
@@ -590,7 +590,6 @@ class TimeToPayProxyControllerSpec extends AnyWordSpec with MockFactory {
           PaymentMethod.DirectDebit,
           PaymentMethod.OnGoingAward
         ).foreach(runUpdatePlanTest)
-      }
 
       "when paymentMethod is not directDebit and paymentReference is missing" in {
         val updatePlanRequestMissingPaymentReference: UpdatePlanRequest =
@@ -601,7 +600,7 @@ class TimeToPayProxyControllerSpec extends AnyWordSpec with MockFactory {
               "planStatus"        -> "success",
               "updateType"        -> "paymentDetails",
               "thirdPartyBank"    -> false,
-              "payments" ->
+              "payments"          ->
                 JsArray(
                   List(
                     Json.obj(
@@ -638,7 +637,7 @@ class TimeToPayProxyControllerSpec extends AnyWordSpec with MockFactory {
               "planId"            -> "planId1234",
               "updateType"        -> "paymentDetails",
               "thirdPartyBank"    -> false,
-              "payments" ->
+              "payments"          ->
                 JsArray(
                   List(
                     Json.obj(
@@ -754,7 +753,7 @@ class TimeToPayProxyControllerSpec extends AnyWordSpec with MockFactory {
               "planId"            -> "planId1234",
               "updateType"        -> "paymentDetails",
               "thirdPartyBank"    -> false,
-              "payments" ->
+              "payments"          ->
                 JsArray(
                   List(
                     Json.obj(
@@ -789,7 +788,7 @@ class TimeToPayProxyControllerSpec extends AnyWordSpec with MockFactory {
             "planId"            -> "planId1234",
             "updateType"        -> "paymentDetails",
             "thirdPartyBank"    -> false,
-            "payments" ->
+            "payments"          ->
               JsArray(
                 List(
                   Json.obj(
@@ -825,7 +824,7 @@ class TimeToPayProxyControllerSpec extends AnyWordSpec with MockFactory {
             "planId"            -> "planId1234",
             "updateType"        -> "paymentDetails",
             "thirdPartyBank"    -> false,
-            "payments" ->
+            "payments"          ->
               JsArray(
                 List(
                   Json.obj(
@@ -888,7 +887,7 @@ class TimeToPayProxyControllerSpec extends AnyWordSpec with MockFactory {
             "planId"            -> "planId1234",
             "updateType"        -> "paymentDetails",
             "thirdPartyBank"    -> false,
-            "payments" ->
+            "payments"          ->
               JsArray(
                 List(
                   Json.obj(

--- a/test/uk/gov/hmrc/timetopayproxy/logging/StatusLoggerSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/logging/StatusLoggerSpec.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.timetopayproxy.logging
 
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import org.scalatest.matchers.should.Matchers.shouldBe
 import play.api.http.Status
 import play.api.test.Helpers.{ await, defaultAwaitTimeout }
 import uk.gov.hmrc.http.HeaderCarrier

--- a/test/uk/gov/hmrc/timetopayproxy/models/CreatePlanRequestSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/models/CreatePlanRequestSpec.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.timetopayproxy.models
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import play.api.libs.json._
+import play.api.libs.json.*
 
 import java.time.LocalDate
 import scala.util.{ Failure, Try }
@@ -326,195 +326,195 @@ trait CreatePlanRequestFixture {
       None
     )
   protected val json = """{
-                         |  "customerReference": "customerReference",
-                         |  "quoteReference":"quoteReference",
-                         |  "channelIdentifier": "advisor",
-                         |  "plan": {
-                         |    "quoteId": "quoteId1",
-                         |    "quoteType": "instalmentAmount",
-                         |    "quoteDate": "2021-05-13",
-                         |    "instalmentStartDate": "2021-05-13",
-                         |    "instalmentAmount": 100,
-                         |    "paymentPlanType": "timeToPay",
-                         |    "thirdPartyBank": true,
-                         |    "numberOfInstalments": 1,
-                         |    "frequency": "annually",
-                         |    "duration": 12,
-                         |    "initialPaymentMethod": "BACS",
-                         |    "initialPaymentReference": "ref123",
-                         |    "initialPaymentDate": "2021-05-13",
-                         |    "initialPaymentAmount": 100,
-                         |    "totalDebtIncInt": 100,
-                         |    "totalInterest": 10,
-                         |    "interestAccrued": 10,
-                         |    "planInterest": 10
-                         |  },
-                         |  "debtItemCharges": [
-                         |    {
-                         |      "debtItemChargeId": "debtItemChargeId1",
-                         |      "mainTrans": "1525",
-                         |      "subTrans": "1000",
-                         |      "originalDebtAmount": 100,
-                         |      "interestStartDate": "2021-05-13",
-                         |      "paymentHistory": [
-                         |        {
-                         |          "paymentDate": "2021-05-13",
-                         |          "paymentAmount": 100
-                         |        }
-                         |      ]
-                         |    }
-                         |  ],
-                         |  "payments": [
-                         |    {
-                         |      "paymentMethod": "BACS",
-                         |      "paymentReference": "ref123"
-                         |    }
-                         |  ],
-                         |  "customerPostCodes": [
-                         |    {
-                         |      "addressPostcode": "NW9 5XW",
-                         |      "postcodeDate": "2021-05-13"
-                         |    }
-                         |  ],
-                         |  "instalments": [
-                         |  {
-                         |    "debtItemChargeId": "debtItemChargeId1",
-                         |    "dueDate": "2021-05-13",
-                         |    "amountDue": 100,
-                         |    "expectedPayment": 100,
-                         |    "interestRate": 0.25,
-                         |    "instalmentNumber": 1,
-                         |    "instalmentInterestAccrued": 10,
-                         |    "instalmentBalance": 90
-                         |  }
-                         |  ]
-                         |}
+    |  "customerReference": "customerReference",
+    |  "quoteReference":"quoteReference",
+    |  "channelIdentifier": "advisor",
+    |  "plan": {
+    |    "quoteId": "quoteId1",
+    |    "quoteType": "instalmentAmount",
+    |    "quoteDate": "2021-05-13",
+    |    "instalmentStartDate": "2021-05-13",
+    |    "instalmentAmount": 100,
+    |    "paymentPlanType": "timeToPay",
+    |    "thirdPartyBank": true,
+    |    "numberOfInstalments": 1,
+    |    "frequency": "annually",
+    |    "duration": 12,
+    |    "initialPaymentMethod": "BACS",
+    |    "initialPaymentReference": "ref123",
+    |    "initialPaymentDate": "2021-05-13",
+    |    "initialPaymentAmount": 100,
+    |    "totalDebtIncInt": 100,
+    |    "totalInterest": 10,
+    |    "interestAccrued": 10,
+    |    "planInterest": 10
+    |  },
+    |  "debtItemCharges": [
+    |    {
+    |      "debtItemChargeId": "debtItemChargeId1",
+    |      "mainTrans": "1525",
+    |      "subTrans": "1000",
+    |      "originalDebtAmount": 100,
+    |      "interestStartDate": "2021-05-13",
+    |      "paymentHistory": [
+    |        {
+    |          "paymentDate": "2021-05-13",
+    |          "paymentAmount": 100
+    |        }
+    |      ]
+    |    }
+    |  ],
+    |  "payments": [
+    |    {
+    |      "paymentMethod": "BACS",
+    |      "paymentReference": "ref123"
+    |    }
+    |  ],
+    |  "customerPostCodes": [
+    |    {
+    |      "addressPostcode": "NW9 5XW",
+    |      "postcodeDate": "2021-05-13"
+    |    }
+    |  ],
+    |  "instalments": [
+    |  {
+    |    "debtItemChargeId": "debtItemChargeId1",
+    |    "dueDate": "2021-05-13",
+    |    "amountDue": 100,
+    |    "expectedPayment": 100,
+    |    "interestRate": 0.25,
+    |    "instalmentNumber": 1,
+    |    "instalmentInterestAccrued": 10,
+    |    "instalmentBalance": 90
+    |  }
+    |  ]
+    |}
                """.stripMargin
   protected val jsonWithEmptyReference = """{
-                                           |  "customerReference": "customerReference",
-                                           |  "quoteReference":"quoteReference",
-                                           |  "channelIdentifier": "advisor",
-                                           |  "plan": {
-                                           |    "quoteId": "quoteId1",
-                                           |    "quoteType": "instalmentAmount",
-                                           |    "quoteDate": "2021-05-13",
-                                           |    "instalmentStartDate": "2021-05-13",
-                                           |    "instalmentAmount": 100,
-                                           |    "paymentPlanType": "timeToPay",
-                                           |    "thirdPartyBank": true,
-                                           |    "numberOfInstalments": 1,
-                                           |    "frequency": "annually",
-                                           |    "duration": 12,
-                                           |    "initialPaymentMethod": "BACS",
-                                           |    "initialPaymentReference": "ref123",
-                                           |    "initialPaymentDate": "2021-05-13",
-                                           |    "initialPaymentAmount": 100,
-                                           |    "totalDebtIncInt": 100,
-                                           |    "totalInterest": 10,
-                                           |    "interestAccrued": 10,
-                                           |    "planInterest": 10
-                                           |  },
-                                           |  "debtItemCharges": [
-                                           |    {
-                                           |      "debtItemChargeId": "debtItemChargeId1",
-                                           |      "mainTrans": "1525",
-                                           |      "subTrans": "1000",
-                                           |      "originalDebtAmount": 100,
-                                           |      "interestStartDate": "2021-05-13",
-                                           |      "paymentHistory": [
-                                           |        {
-                                           |          "paymentDate": "2021-05-13",
-                                           |          "paymentAmount": 100
-                                           |        }
-                                           |      ]
-                                           |    }
-                                           |  ],
-                                           |  "payments": [
-                                           |    {
-                                           |      "paymentMethod": "BACS"
-                                           |    }
-                                           |  ],
-                                           |  "customerPostCodes": [
-                                           |    {
-                                           |      "addressPostcode": "NW9 5XW",
-                                           |      "postcodeDate": "2021-05-13"
-                                           |    }
-                                           |  ],
-                                           |  "instalments": [
-                                           |  {
-                                           |    "debtItemChargeId": "debtItemChargeId1",
-                                           |    "dueDate": "2021-05-13",
-                                           |    "amountDue": 100,
-                                           |    "expectedPayment": 100,
-                                           |    "interestRate": 0.25,
-                                           |    "instalmentNumber": 1,
-                                           |    "instalmentInterestAccrued": 10,
-                                           |    "instalmentBalance": 90
-                                           |  }
-                                           |  ]
-                                           |}
+    |  "customerReference": "customerReference",
+    |  "quoteReference":"quoteReference",
+    |  "channelIdentifier": "advisor",
+    |  "plan": {
+    |    "quoteId": "quoteId1",
+    |    "quoteType": "instalmentAmount",
+    |    "quoteDate": "2021-05-13",
+    |    "instalmentStartDate": "2021-05-13",
+    |    "instalmentAmount": 100,
+    |    "paymentPlanType": "timeToPay",
+    |    "thirdPartyBank": true,
+    |    "numberOfInstalments": 1,
+    |    "frequency": "annually",
+    |    "duration": 12,
+    |    "initialPaymentMethod": "BACS",
+    |    "initialPaymentReference": "ref123",
+    |    "initialPaymentDate": "2021-05-13",
+    |    "initialPaymentAmount": 100,
+    |    "totalDebtIncInt": 100,
+    |    "totalInterest": 10,
+    |    "interestAccrued": 10,
+    |    "planInterest": 10
+    |  },
+    |  "debtItemCharges": [
+    |    {
+    |      "debtItemChargeId": "debtItemChargeId1",
+    |      "mainTrans": "1525",
+    |      "subTrans": "1000",
+    |      "originalDebtAmount": 100,
+    |      "interestStartDate": "2021-05-13",
+    |      "paymentHistory": [
+    |        {
+    |          "paymentDate": "2021-05-13",
+    |          "paymentAmount": 100
+    |        }
+    |      ]
+    |    }
+    |  ],
+    |  "payments": [
+    |    {
+    |      "paymentMethod": "BACS"
+    |    }
+    |  ],
+    |  "customerPostCodes": [
+    |    {
+    |      "addressPostcode": "NW9 5XW",
+    |      "postcodeDate": "2021-05-13"
+    |    }
+    |  ],
+    |  "instalments": [
+    |  {
+    |    "debtItemChargeId": "debtItemChargeId1",
+    |    "dueDate": "2021-05-13",
+    |    "amountDue": 100,
+    |    "expectedPayment": 100,
+    |    "interestRate": 0.25,
+    |    "instalmentNumber": 1,
+    |    "instalmentInterestAccrued": 10,
+    |    "instalmentBalance": 90
+    |  }
+    |  ]
+    |}
                """.stripMargin
   protected val jsonWithDirectDebitAndEmptyReference = """{
-                                                         |  "customerReference": "customerReference",
-                                                         |  "quoteReference":"quoteReference",
-                                                         |  "channelIdentifier": "advisor",
-                                                         |  "plan": {
-                                                         |    "quoteId": "quoteId1",
-                                                         |    "quoteType": "instalmentAmount",
-                                                         |    "quoteDate": "2021-05-13",
-                                                         |    "instalmentStartDate": "2021-05-13",
-                                                         |    "instalmentAmount": 100,
-                                                         |    "paymentPlanType": "timeToPay",
-                                                         |    "thirdPartyBank": true,
-                                                         |    "numberOfInstalments": 1,
-                                                         |    "frequency": "annually",
-                                                         |    "duration": 12,
-                                                         |    "initialPaymentDate": "2021-05-13",
-                                                         |    "initialPaymentAmount": 100,
-                                                         |    "totalDebtIncInt": 100,
-                                                         |    "totalInterest": 10,
-                                                         |    "interestAccrued": 10,
-                                                         |    "planInterest": 10
-                                                         |  },
-                                                         |  "debtItemCharges": [
-                                                         |    {
-                                                         |      "debtItemChargeId": "debtItemChargeId1",
-                                                         |      "mainTrans": "1525",
-                                                         |      "subTrans": "1000",
-                                                         |      "originalDebtAmount": 100,
-                                                         |      "interestStartDate": "2021-05-13",
-                                                         |      "paymentHistory": [
-                                                         |        {
-                                                         |          "paymentDate": "2021-05-13",
-                                                         |          "paymentAmount": 100
-                                                         |        }
-                                                         |      ]
-                                                         |    }
-                                                         |  ],
-                                                         |  "payments": [
-                                                         |    {
-                                                         |      "paymentMethod": "directDebit"
-                                                         |    }
-                                                         |  ],
-                                                         |  "customerPostCodes": [
-                                                         |    {
-                                                         |      "addressPostcode": "NW9 5XW",
-                                                         |      "postcodeDate": "2021-05-13"
-                                                         |    }
-                                                         |  ],
-                                                         |  "instalments": [
-                                                         |  {
-                                                         |    "debtItemChargeId": "debtItemChargeId1",
-                                                         |    "dueDate": "2021-05-13",
-                                                         |    "amountDue": 100,
-                                                         |    "expectedPayment": 100,
-                                                         |    "interestRate": 0.25,
-                                                         |    "instalmentNumber": 1,
-                                                         |    "instalmentInterestAccrued": 10,
-                                                         |    "instalmentBalance": 90
-                                                         |  }
-                                                         |  ]
-                                                         |}
+    |  "customerReference": "customerReference",
+    |  "quoteReference":"quoteReference",
+    |  "channelIdentifier": "advisor",
+    |  "plan": {
+    |    "quoteId": "quoteId1",
+    |    "quoteType": "instalmentAmount",
+    |    "quoteDate": "2021-05-13",
+    |    "instalmentStartDate": "2021-05-13",
+    |    "instalmentAmount": 100,
+    |    "paymentPlanType": "timeToPay",
+    |    "thirdPartyBank": true,
+    |    "numberOfInstalments": 1,
+    |    "frequency": "annually",
+    |    "duration": 12,
+    |    "initialPaymentDate": "2021-05-13",
+    |    "initialPaymentAmount": 100,
+    |    "totalDebtIncInt": 100,
+    |    "totalInterest": 10,
+    |    "interestAccrued": 10,
+    |    "planInterest": 10
+    |  },
+    |  "debtItemCharges": [
+    |    {
+    |      "debtItemChargeId": "debtItemChargeId1",
+    |      "mainTrans": "1525",
+    |      "subTrans": "1000",
+    |      "originalDebtAmount": 100,
+    |      "interestStartDate": "2021-05-13",
+    |      "paymentHistory": [
+    |        {
+    |          "paymentDate": "2021-05-13",
+    |          "paymentAmount": 100
+    |        }
+    |      ]
+    |    }
+    |  ],
+    |  "payments": [
+    |    {
+    |      "paymentMethod": "directDebit"
+    |    }
+    |  ],
+    |  "customerPostCodes": [
+    |    {
+    |      "addressPostcode": "NW9 5XW",
+    |      "postcodeDate": "2021-05-13"
+    |    }
+    |  ],
+    |  "instalments": [
+    |  {
+    |    "debtItemChargeId": "debtItemChargeId1",
+    |    "dueDate": "2021-05-13",
+    |    "amountDue": 100,
+    |    "expectedPayment": 100,
+    |    "interestRate": 0.25,
+    |    "instalmentNumber": 1,
+    |    "instalmentInterestAccrued": 10,
+    |    "instalmentBalance": 90
+    |  }
+    |  ]
+    |}
                """.stripMargin
   protected def getJsonWithInvalidReference(
     quoteReference: QuoteReference = QuoteReference("quoteReference"),
@@ -538,67 +538,67 @@ trait CreatePlanRequestFixture {
     addressPostcode: String = "NW9 5XW"
   ) =
     s"""{
-       |  "customerReference": "${customerReference.value}",
-       |  "quoteReference":"${quoteReference.value}",
-       |  "channelIdentifier": "advisor",
-       |  "plan": {
-       |    "quoteId": "quoteId1",
-       |    "quoteType": "instalmentAmount",
-       |    "quoteDate": "2021-05-13",
-       |    "instalmentStartDate": "2021-05-13",
-       |    "instalmentAmount": $instalmentAmount,
-       |    "paymentPlanType": "timeToPay",
-       |    "thirdPartyBank": true,
-       |    "numberOfInstalments": $numberOfInstalments,
-       |    "frequency": "annually",
-       |    "duration": 12,
-       |    "initialPaymentDate": "2021-05-13",
-       |    "initialPaymentAmount": $initialPaymentAmount,
-       |    "totalDebtIncInt": $totalDebtIncInt,
-       |    "totalInterest": $totalInterest,
-       |    "interestAccrued": $interestAccrued,
-       |    "planInterest": $planInterest
-       |  },
-       |  "debtItemCharges": [
-       |    {
-       |      "debtItemChargeId": "debtItemChargeId1",
-       |      "mainTrans": "1525",
-       |      "subTrans": "1000",
-       |      "originalDebtAmount": $originalDebtAmount,
-       |      "interestStartDate": "2021-05-13",
-       |      "paymentHistory": [
-       |        {
-       |          "paymentDate": "2021-05-13",
-       |          "paymentAmount": $paymentAmount
-       |        }
-       |      ]
-       |    }
-       |  ],
-       |  "payments": [
-       |    {
-       |      "paymentMethod": "BACS",
-       |      "paymentReference": "${paymentReference.value}"
-       |    }
-       |  ],
-       |  "customerPostCodes": [
-       |    {
-       |      "addressPostcode": "$addressPostcode",
-       |      "postcodeDate": "2021-05-13"
-       |    }
-       |  ],
-       |  "instalments": [
-       |  {
-       |    "debtItemChargeId": "debtItemChargeId1",
-       |    "dueDate": "2021-05-13",
-       |    "amountDue": $amountDue,
-       |    "expectedPayment": $expectedPayment,
-       |    "interestRate": $interestRate,
-       |    "instalmentNumber": $instalmentNumber,
-       |    "instalmentInterestAccrued": $instalmentInterestAccrued,
-       |    "instalmentBalance": $instalmentBalance
-       |  }
-       |  ]
-       |}
+      |  "customerReference": "${customerReference.value}",
+      |  "quoteReference":"${quoteReference.value}",
+      |  "channelIdentifier": "advisor",
+      |  "plan": {
+      |    "quoteId": "quoteId1",
+      |    "quoteType": "instalmentAmount",
+      |    "quoteDate": "2021-05-13",
+      |    "instalmentStartDate": "2021-05-13",
+      |    "instalmentAmount": $instalmentAmount,
+      |    "paymentPlanType": "timeToPay",
+      |    "thirdPartyBank": true,
+      |    "numberOfInstalments": $numberOfInstalments,
+      |    "frequency": "annually",
+      |    "duration": 12,
+      |    "initialPaymentDate": "2021-05-13",
+      |    "initialPaymentAmount": $initialPaymentAmount,
+      |    "totalDebtIncInt": $totalDebtIncInt,
+      |    "totalInterest": $totalInterest,
+      |    "interestAccrued": $interestAccrued,
+      |    "planInterest": $planInterest
+      |  },
+      |  "debtItemCharges": [
+      |    {
+      |      "debtItemChargeId": "debtItemChargeId1",
+      |      "mainTrans": "1525",
+      |      "subTrans": "1000",
+      |      "originalDebtAmount": $originalDebtAmount,
+      |      "interestStartDate": "2021-05-13",
+      |      "paymentHistory": [
+      |        {
+      |          "paymentDate": "2021-05-13",
+      |          "paymentAmount": $paymentAmount
+      |        }
+      |      ]
+      |    }
+      |  ],
+      |  "payments": [
+      |    {
+      |      "paymentMethod": "BACS",
+      |      "paymentReference": "${paymentReference.value}"
+      |    }
+      |  ],
+      |  "customerPostCodes": [
+      |    {
+      |      "addressPostcode": "$addressPostcode",
+      |      "postcodeDate": "2021-05-13"
+      |    }
+      |  ],
+      |  "instalments": [
+      |  {
+      |    "debtItemChargeId": "debtItemChargeId1",
+      |    "dueDate": "2021-05-13",
+      |    "amountDue": $amountDue,
+      |    "expectedPayment": $expectedPayment,
+      |    "interestRate": $interestRate,
+      |    "instalmentNumber": $instalmentNumber,
+      |    "instalmentInterestAccrued": $instalmentInterestAccrued,
+      |    "instalmentBalance": $instalmentBalance
+      |  }
+      |  ]
+      |}
     """.stripMargin
 
   protected val createPlanRequestWithEmptyReference =

--- a/test/uk/gov/hmrc/timetopayproxy/models/GenerateQuoteRequestSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/models/GenerateQuoteRequestSpec.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.timetopayproxy.models
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import play.api.libs.json._
+import play.api.libs.json.*
 import uk.gov.hmrc.timetopayproxy.models.saonly.common.SaOnlyRegimeType
 
 import java.time.LocalDate
@@ -54,43 +54,43 @@ class GenerateQuoteRequestSpec extends AnyWordSpec with Matchers {
   )
 
   val json = """{
-               |  "customerReference": "uniqRef1234",
-               |  "channelIdentifier": "selfService",
-               |  "plan": {
-               |    "quoteType": "instalmentAmount",
-               |    "quoteDate": "2021-05-13",
-               |    "instalmentStartDate": "2021-05-13",
-               |    "instalmentAmount": 100,
-               |    "frequency": "annually",
-               |    "duration": 12,
-               |    "initialPaymentAmount": 100,
-               |    "initialPaymentDate": "2021-05-13",
-               |    "paymentPlanType": "timeToPay"
-               |  },
-               |  "customerPostCodes": [
-               |    {
-               |      "addressPostcode": "NW9 5XW",
-               |      "postcodeDate": "2021-05-13"
-               |    }
-               |  ],
-               |  "debtItemCharges": [
-               |    {
-               |      "debtItemChargeId": "debtItemChargeId1",
-               |      "mainTrans": "5330",
-               |      "subTrans": "1180",
-               |      "originalDebtAmount": 100,
-               |      "interestStartDate": "2021-05-13",
-               |      "paymentHistory": [
-               |        {
-               |          "paymentDate": "2021-05-13",
-               |          "paymentAmount": 100
-               |        }
-               |      ],
-               |      "dueDate": "2021-05-13"
-               |    }
-               |  ],
-               |  "regimeType": "SA"
-               |}
+    |  "customerReference": "uniqRef1234",
+    |  "channelIdentifier": "selfService",
+    |  "plan": {
+    |    "quoteType": "instalmentAmount",
+    |    "quoteDate": "2021-05-13",
+    |    "instalmentStartDate": "2021-05-13",
+    |    "instalmentAmount": 100,
+    |    "frequency": "annually",
+    |    "duration": 12,
+    |    "initialPaymentAmount": 100,
+    |    "initialPaymentDate": "2021-05-13",
+    |    "paymentPlanType": "timeToPay"
+    |  },
+    |  "customerPostCodes": [
+    |    {
+    |      "addressPostcode": "NW9 5XW",
+    |      "postcodeDate": "2021-05-13"
+    |    }
+    |  ],
+    |  "debtItemCharges": [
+    |    {
+    |      "debtItemChargeId": "debtItemChargeId1",
+    |      "mainTrans": "5330",
+    |      "subTrans": "1180",
+    |      "originalDebtAmount": 100,
+    |      "interestStartDate": "2021-05-13",
+    |      "paymentHistory": [
+    |        {
+    |          "paymentDate": "2021-05-13",
+    |          "paymentAmount": 100
+    |        }
+    |      ],
+    |      "dueDate": "2021-05-13"
+    |    }
+    |  ],
+    |  "regimeType": "SA"
+    |}
                """.stripMargin
 
   def getJsonWithInvalidReference(
@@ -104,43 +104,43 @@ class GenerateQuoteRequestSpec extends AnyWordSpec with Matchers {
     quoteType: String = "instalmentAmount",
     regimeType: String = "SA"
   ) = s"""{
-         |  "customerReference": "$customerReference",
-         |  "channelIdentifier": "selfService",
-         |  "plan": {
-         |    "quoteType": "$quoteType",
-         |    "quoteDate": "2021-05-13",
-         |    "instalmentStartDate": "2021-05-13",
-         |    "instalmentAmount": $instalmentAmount,
-         |    "frequency": "annually",
-         |    "duration": 12,
-         |    "initialPaymentAmount": $initialPaymentAmount,
-         |    "initialPaymentDate": "2021-05-13",
-         |    "paymentPlanType": "timeToPay"
-         |  },
-         |  "customerPostCodes": [
-         |    {
-         |      "addressPostcode": "$addressPostcode",
-         |      "postcodeDate": "2021-05-13"
-         |    }
-         |  ],
-         |  "debtItemCharges": [
-         |    {
-         |      "debtItemChargeId": "$debtItemChargeId",
-         |      "mainTrans": "5330",
-         |      "subTrans": "1180",
-         |      "originalDebtAmount": $originalDebtAmount,
-         |      "interestStartDate": "2021-05-13",
-         |      "paymentHistory": [
-         |        {
-         |          "paymentDate": "2021-05-13",
-         |          "paymentAmount": $paymentAmount
-         |        }
-         |      ],
-         |      "dueDate": "2021-05-13"
-         |    }
-         |  ],
-         |  "regimeType": "$regimeType"
-         |}
+    |  "customerReference": "$customerReference",
+    |  "channelIdentifier": "selfService",
+    |  "plan": {
+    |    "quoteType": "$quoteType",
+    |    "quoteDate": "2021-05-13",
+    |    "instalmentStartDate": "2021-05-13",
+    |    "instalmentAmount": $instalmentAmount,
+    |    "frequency": "annually",
+    |    "duration": 12,
+    |    "initialPaymentAmount": $initialPaymentAmount,
+    |    "initialPaymentDate": "2021-05-13",
+    |    "paymentPlanType": "timeToPay"
+    |  },
+    |  "customerPostCodes": [
+    |    {
+    |      "addressPostcode": "$addressPostcode",
+    |      "postcodeDate": "2021-05-13"
+    |    }
+    |  ],
+    |  "debtItemCharges": [
+    |    {
+    |      "debtItemChargeId": "$debtItemChargeId",
+    |      "mainTrans": "5330",
+    |      "subTrans": "1180",
+    |      "originalDebtAmount": $originalDebtAmount,
+    |      "interestStartDate": "2021-05-13",
+    |      "paymentHistory": [
+    |        {
+    |          "paymentDate": "2021-05-13",
+    |          "paymentAmount": $paymentAmount
+    |        }
+    |      ],
+    |      "dueDate": "2021-05-13"
+    |    }
+    |  ],
+    |  "regimeType": "$regimeType"
+    |}
              """.stripMargin
 
   "GenerateQuoteRequest" should {

--- a/test/uk/gov/hmrc/timetopayproxy/models/GenerateQuoteResponseSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/models/GenerateQuoteResponseSpec.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.timetopayproxy.models
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import play.api.libs.json._
+import play.api.libs.json.*
 
 import java.time.LocalDate
 
@@ -55,41 +55,41 @@ class GenerateQuoteResponseSpec extends AnyWordSpec with Matchers {
   )
 
   val json = """{
-               |  "quoteReference": "quoteRef1234",
-               |  "customerReference": "custRef1234",
-               |  "quoteType": "instalmentAmount",
-               |  "quoteDate": "2021-05-13",
-               |  "numberOfInstalments": 1,
-               |  "totalDebtIncInt": 10,
-               |  "interestAccrued": 10,
-               |  "planInterest": 0.25,
-               |  "totalInterest": 0.25,
-               |  "instalments": [
-               |    {
-               |      "debtItemChargeId": "debtItemChargeId1",
-               |      "dueDate": "2021-05-13",
-               |      "amountDue": 100,
-               |      "expectedPayment": 100,
-               |      "interestRate": 0.24,
-               |      "instalmentNumber": 1,
-               |      "instalmentInterestAccrued": 10,
-               |      "instalmentBalance": 10
-               |    }
-               |  ],
-               | "collections": {
-               |    "initialCollection": {
-               |      "dueDate": "2022-06-18",
-               |      "amountDue": 1000
-               |    },
-               |    "regularCollections": [{
-               |      "dueDate": "2022-07-08",
-               |      "amountDue": 1628.21
-               |    }, {
-               |      "dueDate": "2022-08-08",
-               |      "amountDue": 1628.21
-               |    }]
-               |  }
-               |}""".stripMargin
+    |  "quoteReference": "quoteRef1234",
+    |  "customerReference": "custRef1234",
+    |  "quoteType": "instalmentAmount",
+    |  "quoteDate": "2021-05-13",
+    |  "numberOfInstalments": 1,
+    |  "totalDebtIncInt": 10,
+    |  "interestAccrued": 10,
+    |  "planInterest": 0.25,
+    |  "totalInterest": 0.25,
+    |  "instalments": [
+    |    {
+    |      "debtItemChargeId": "debtItemChargeId1",
+    |      "dueDate": "2021-05-13",
+    |      "amountDue": 100,
+    |      "expectedPayment": 100,
+    |      "interestRate": 0.24,
+    |      "instalmentNumber": 1,
+    |      "instalmentInterestAccrued": 10,
+    |      "instalmentBalance": 10
+    |    }
+    |  ],
+    | "collections": {
+    |    "initialCollection": {
+    |      "dueDate": "2022-06-18",
+    |      "amountDue": 1000
+    |    },
+    |    "regularCollections": [{
+    |      "dueDate": "2022-07-08",
+    |      "amountDue": 1628.21
+    |    }, {
+    |      "dueDate": "2022-08-08",
+    |      "amountDue": 1628.21
+    |    }]
+    |  }
+    |}""".stripMargin
 
   "GenerateQuoteResponse" should {
     "be correctly encoded and decoded" in {

--- a/test/uk/gov/hmrc/timetopayproxy/models/TimeToPayEligibilityErrorSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/models/TimeToPayEligibilityErrorSpec.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.timetopayproxy.models
 
 import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers._
+import org.scalatest.matchers.should.Matchers.*
 import play.api.libs.json.{ JsSuccess, JsValue, Json, Reads }
 import uk.gov.hmrc.timetopayproxy.testutils.schematestutils.Validators
 

--- a/test/uk/gov/hmrc/timetopayproxy/models/TimeToPayErrorSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/models/TimeToPayErrorSpec.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.timetopayproxy.models
 
 import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers._
+import org.scalatest.matchers.should.Matchers.*
 import play.api.libs.json.{ JsSuccess, JsValue, Json, Reads }
 
 final class TimeToPayErrorSpec extends AnyFreeSpec {

--- a/test/uk/gov/hmrc/timetopayproxy/models/TtppErrorResponseSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/models/TtppErrorResponseSpec.scala
@@ -17,10 +17,10 @@
 package uk.gov.hmrc.timetopayproxy.models
 
 import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers._
+import org.scalatest.matchers.should.Matchers.*
 import play.api.libs.json.{ JsValue, Json, Writes }
 import uk.gov.hmrc.timetopayproxy.models.error.TtppErrorResponse
-import uk.gov.hmrc.timetopayproxy.testutils.JsonAssertionOps._
+import uk.gov.hmrc.timetopayproxy.testutils.JsonAssertionOps.*
 import uk.gov.hmrc.timetopayproxy.testutils.schematestutils.Validators
 
 final class TtppErrorResponseSpec extends AnyFreeSpec {

--- a/test/uk/gov/hmrc/timetopayproxy/models/UpdatePlanRequestSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/models/UpdatePlanRequestSpec.scala
@@ -17,8 +17,8 @@
 package uk.gov.hmrc.timetopayproxy.models
 
 import org.scalatest.freespec.AnyFreeSpecLike
-import org.scalatest.matchers.should.Matchers._
-import org.scalatest.prop.TableDrivenPropertyChecks._
+import org.scalatest.matchers.should.Matchers.*
+import org.scalatest.prop.TableDrivenPropertyChecks.*
 import play.api.libs.json.{ JsString, JsValue, Json }
 
 class UpdatePlanRequestSpec extends AnyFreeSpecLike {
@@ -39,22 +39,22 @@ class UpdatePlanRequestSpec extends AnyFreeSpecLike {
 
       val updatePlanRequestJson: JsValue =
         Json.parse("""{
-                     |  "customerReference": "custRef123",
-                     |  "planId": "planId1",
-                     |  "updateType": "paymentDetails",
-                     |  "channelIdentifier": "selfService",
-                     |  "planStatus": "Resolved - Completed",
-                     |  "completeReason": "Payment in Full",
-                     |  "cancellationReason": "debt-resolved",
-                     |  "thirdPartyBank": true,
-                     |  "payments":
-                     |  [
-                     |    {
-                     |      "paymentMethod": "Bank payments",
-                     |      "paymentReference": "paymentRef"
-                     |    }
-                     |  ]
-                     |}""".stripMargin)
+          |  "customerReference": "custRef123",
+          |  "planId": "planId1",
+          |  "updateType": "paymentDetails",
+          |  "channelIdentifier": "selfService",
+          |  "planStatus": "Resolved - Completed",
+          |  "completeReason": "Payment in Full",
+          |  "cancellationReason": "debt-resolved",
+          |  "thirdPartyBank": true,
+          |  "payments":
+          |  [
+          |    {
+          |      "paymentMethod": "Bank payments",
+          |      "paymentReference": "paymentRef"
+          |    }
+          |  ]
+          |}""".stripMargin)
 
       "should be deserialized correctly" in {
         updatePlanRequestJson.as[UpdatePlanRequest] shouldBe updatePlanRequest
@@ -81,10 +81,10 @@ class UpdatePlanRequestSpec extends AnyFreeSpecLike {
 
       val updatePlanRequestJson: JsValue =
         Json.parse("""{
-                     |  "customerReference": "custRef123",
-                     |  "planId": "planId1",
-                     |  "updateType": "paymentDetails"
-                     |}""".stripMargin)
+          |  "customerReference": "custRef123",
+          |  "planId": "planId1",
+          |  "updateType": "paymentDetails"
+          |}""".stripMargin)
 
       "should be deserialized correctly" in {
         updatePlanRequestJson.as[UpdatePlanRequest] shouldBe updatePlanRequest
@@ -100,11 +100,11 @@ class UpdatePlanRequestSpec extends AnyFreeSpecLike {
         "should deserialize correctly" in {
           val updatePlanRequestJson: JsValue =
             Json.parse("""{
-                         |  "customerReference": "custRef123",
-                         |  "planId": "planId1",
-                         |  "updateType": "planStatus",
-                         |  "planStatus": "Resolved - Completed"
-                         |}""".stripMargin)
+              |  "customerReference": "custRef123",
+              |  "planId": "planId1",
+              |  "updateType": "planStatus",
+              |  "planStatus": "Resolved - Completed"
+              |}""".stripMargin)
 
           val updatePlanRequest: UpdatePlanRequest =
             UpdatePlanRequest(
@@ -127,10 +127,10 @@ class UpdatePlanRequestSpec extends AnyFreeSpecLike {
         "should throw an error when deserializing" in {
           val updatePlanRequestJson: JsValue =
             Json.parse("""{
-                         |  "customerReference": "custRef123",
-                         |  "planId": "planId1",
-                         |  "updateType": "planStatus"
-                         |}""".stripMargin)
+              |  "customerReference": "custRef123",
+              |  "planId": "planId1",
+              |  "updateType": "planStatus"
+              |}""".stripMargin)
 
           val deserializationError: IllegalArgumentException = intercept[IllegalArgumentException](
             updatePlanRequestJson.as[UpdatePlanRequest]
@@ -155,21 +155,19 @@ class UpdatePlanRequestSpec extends AnyFreeSpecLike {
         PaymentMethod.OnGoingAward -> "Ongoing award"
       )
 
-    "should be deserialized correctly" in {
+    "should be deserialized correctly" in
       forAll(paymentMethodMappings) { case (paymentMethod, entryName) =>
         val paymentMethodJson: JsValue = JsString(entryName)
 
         paymentMethodJson.as[PaymentMethod] shouldBe paymentMethod
       }
-    }
 
-    "should be serialized correctly" in {
+    "should be serialized correctly" in
       forAll(paymentMethodMappings) { case (paymentMethod, entryName) =>
         val paymentMethodJson: JsValue = JsString(entryName)
 
         Json.toJson(paymentMethod) shouldBe paymentMethodJson
       }
-    }
 
     ".values" - {
       val paymentMethodEnums: Seq[PaymentMethod] =

--- a/test/uk/gov/hmrc/timetopayproxy/models/affordablequotes/AffordableQuoteResponseSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/models/affordablequotes/AffordableQuoteResponseSpec.scala
@@ -17,10 +17,10 @@
 package uk.gov.hmrc.timetopayproxy.models.affordablequotes
 
 import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers._
+import org.scalatest.matchers.should.Matchers.*
 import play.api.libs.json.{ JsSuccess, JsValue, Json, Reads, Writes }
 import uk.gov.hmrc.timetopayproxy.models.{ Collections, DebtItemChargeId, Duration, InitialCollection, RegularCollection }
-import uk.gov.hmrc.timetopayproxy.testutils.JsonAssertionOps._
+import uk.gov.hmrc.timetopayproxy.testutils.JsonAssertionOps.*
 import uk.gov.hmrc.timetopayproxy.testutils.schematestutils.Validators
 
 import java.time.{ LocalDate, LocalDateTime }
@@ -207,9 +207,8 @@ final class AffordableQuoteResponseSpec extends AnyFreeSpec {
 
         def obj: AffordableQuoteResponse = TestData.WithOnlySomes.obj
 
-        "writes the correct JSON" in {
-          writerToClients.writes(obj) shouldBeEquivalentTo json
-        }
+        "writes the correct JSON" in
+          writerToClients.writes(obj).shouldBeEquivalentTo(json)
 
         "writes JSON compatible with our schema" in {
           val schema = Validators.TimeToPayProxy.AffordableQuotes.openApiResponseSuccessfulSchema
@@ -223,9 +222,8 @@ final class AffordableQuoteResponseSpec extends AnyFreeSpec {
         def json: JsValue = TestData.With0Somes.json
         def obj: AffordableQuoteResponse = TestData.With0Somes.obj
 
-        "writes the correct JSON" in {
-          writerToClients.writes(obj) shouldBeEquivalentTo json
-        }
+        "writes the correct JSON" in
+          writerToClients.writes(obj).shouldBeEquivalentTo(json)
 
         "writes JSON compatible with our schema" in {
           val schema = Validators.TimeToPayProxy.AffordableQuotes.openApiResponseSuccessfulSchema

--- a/test/uk/gov/hmrc/timetopayproxy/models/affordablequotes/AffordableQuotesRequestSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/models/affordablequotes/AffordableQuotesRequestSpec.scala
@@ -17,10 +17,10 @@
 package uk.gov.hmrc.timetopayproxy.models.affordablequotes
 
 import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers._
+import org.scalatest.matchers.should.Matchers.*
 import play.api.libs.json.{ JsSuccess, JsValue, Json, Reads, Writes }
 import uk.gov.hmrc.timetopayproxy.models.{ CustomerPostCode, DebtItemChargeId, DebtItemChargeSelfServe, Duration, FrequencyCapitalised, IsInterestBearingCharge, PostCode, SsttpRegimeType, UseChargeReference }
-import uk.gov.hmrc.timetopayproxy.testutils.JsonAssertionOps._
+import uk.gov.hmrc.timetopayproxy.testutils.JsonAssertionOps.*
 import uk.gov.hmrc.timetopayproxy.testutils.schematestutils.Validators
 
 import java.time.LocalDate

--- a/test/uk/gov/hmrc/timetopayproxy/models/currency/GbpPoundsSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/models/currency/GbpPoundsSpec.scala
@@ -16,12 +16,12 @@
 
 package uk.gov.hmrc.timetopayproxy.models.currency
 
-import org.scalatest.EitherValues._
+import org.scalatest.EitherValues.*
 import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers._
+import org.scalatest.matchers.should.Matchers.*
 import play.api.libs.json.{ JsError, JsResult, Json, Reads, Writes }
 
-import java.math.{ BigDecimal => JavaBigDecimal, MathContext, RoundingMode }
+import java.math.{ BigDecimal as JavaBigDecimal, MathContext, RoundingMode }
 
 final class GbpPoundsSpec extends AnyFreeSpec {
   "GbpPounds" - {

--- a/test/uk/gov/hmrc/timetopayproxy/models/saonly/chargeInfoApi/ChargeInfoRequestSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/models/saonly/chargeInfoApi/ChargeInfoRequestSpec.scala
@@ -18,11 +18,11 @@ package uk.gov.hmrc.timetopayproxy.models.saonly.chargeInfoApi
 
 import cats.data.NonEmptyList
 import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers._
+import org.scalatest.matchers.should.Matchers.*
 import play.api.libs.json.{ JsSuccess, JsValue, Json, Reads, Writes }
 import uk.gov.hmrc.timetopayproxy.models.saonly.common.SaOnlyRegimeType
 import uk.gov.hmrc.timetopayproxy.models.{ IdType, IdValue, Identification }
-import uk.gov.hmrc.timetopayproxy.testutils.JsonAssertionOps._
+import uk.gov.hmrc.timetopayproxy.testutils.JsonAssertionOps.*
 import uk.gov.hmrc.timetopayproxy.testutils.schematestutils.Validators
 
 class ChargeInfoRequestSpec extends AnyFreeSpec {

--- a/test/uk/gov/hmrc/timetopayproxy/models/saonly/chargeInfoApi/ChargeInfoResponseSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/models/saonly/chargeInfoApi/ChargeInfoResponseSpec.scala
@@ -19,8 +19,8 @@ package uk.gov.hmrc.timetopayproxy.models.saonly.chargeInfoApi
 import org.scalactic.source.Position
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers._
-import play.api.libs.json._
+import org.scalatest.matchers.should.Matchers.*
+import play.api.libs.json.*
 import uk.gov.hmrc.timetopayproxy.config.FeatureSwitch
 import uk.gov.hmrc.timetopayproxy.models.featureSwitches.SaRelease2Enabled
 import uk.gov.hmrc.timetopayproxy.models.saonly.chargeInfoApi.ChargeInfoTestData.TestData

--- a/test/uk/gov/hmrc/timetopayproxy/models/saonly/chargeInfoApi/ChargeInfoTestData.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/models/saonly/chargeInfoApi/ChargeInfoTestData.scala
@@ -261,56 +261,56 @@ object ChargeInfoTestData {
 
       def chargeInfoResponseR2JsonFromEligibility: JsObject = chargeInfoResponseR1JsonFromEligibility ++ Json
         .parse("""{
-                 |  "customerSignals": [
-                 |    {
-                 |      "signalType": "Rls",
-                 |      "signalValue": "signal value",
-                 |      "signalDescription": "description"
-                 |    },
-                 |    {
-                 |      "signalType": "Welsh Language Signal",
-                 |      "signalValue": "signal value",
-                 |      "signalDescription": "description"
-                 |    }
-                 |  ],
-                 |  "chargeTypeAssessment" : [
-                 |    {
-                 |      "chargeReference" : "CHARGE REFERENCE",
-                 |      "charges" : [
-                 |        {
-                 |          "accruedInterest" : 50,
-                 |          "chargeSource" : "Source",
-                 |          "chargeType" : "charge type",
-                 |          "creationDate" : "2025-07-02",
-                 |          "dueDate" : "2021-01-31",
-                 |          "interestStartDate" : "2020-01-03",
-                 |          "isInterestBearingCharge" : true,
-                 |          "mainType" : "main type",
-                 |          "originalChargeType" : "Original Charge Type",
-                 |          "outstandingAmount" : 500,
-                 |          "parentMainTrans" : "Parent Main Transaction",
-                 |          "saTaxYearEnd" : "2020-04-05",
-                 |          "subTrans" : "1000",
-                 |          "taxPeriodFrom" : "2020-01-02",
-                 |          "taxPeriodTo" : "2020-12-31",
-                 |          "tieBreaker" : "Tie Breaker",
-                 |          "locks": [
-                 |            {
-                 |              "lockType": "Posting/Clearing",
-                 |              "lockReason": "No Reallocation"
-                 |            }
-                 |          ]
-                 |        }
-                 |      ],
-                 |      "debtTotalAmount" : 1000,
-                 |      "mainTrans" : "2000",
-                 |      "parentChargeReference" : "PARENT CHARGE REF",
-                 |      "isInsolvent": false
-                 |    }
-                 |  ],
-                 |  "chargeTypesExcluded" : false
-                 |}
-                 |""".stripMargin)
+          |  "customerSignals": [
+          |    {
+          |      "signalType": "Rls",
+          |      "signalValue": "signal value",
+          |      "signalDescription": "description"
+          |    },
+          |    {
+          |      "signalType": "Welsh Language Signal",
+          |      "signalValue": "signal value",
+          |      "signalDescription": "description"
+          |    }
+          |  ],
+          |  "chargeTypeAssessment" : [
+          |    {
+          |      "chargeReference" : "CHARGE REFERENCE",
+          |      "charges" : [
+          |        {
+          |          "accruedInterest" : 50,
+          |          "chargeSource" : "Source",
+          |          "chargeType" : "charge type",
+          |          "creationDate" : "2025-07-02",
+          |          "dueDate" : "2021-01-31",
+          |          "interestStartDate" : "2020-01-03",
+          |          "isInterestBearingCharge" : true,
+          |          "mainType" : "main type",
+          |          "originalChargeType" : "Original Charge Type",
+          |          "outstandingAmount" : 500,
+          |          "parentMainTrans" : "Parent Main Transaction",
+          |          "saTaxYearEnd" : "2020-04-05",
+          |          "subTrans" : "1000",
+          |          "taxPeriodFrom" : "2020-01-02",
+          |          "taxPeriodTo" : "2020-12-31",
+          |          "tieBreaker" : "Tie Breaker",
+          |          "locks": [
+          |            {
+          |              "lockType": "Posting/Clearing",
+          |              "lockReason": "No Reallocation"
+          |            }
+          |          ]
+          |        }
+          |      ],
+          |      "debtTotalAmount" : 1000,
+          |      "mainTrans" : "2000",
+          |      "parentChargeReference" : "PARENT CHARGE REF",
+          |      "isInsolvent": false
+          |    }
+          |  ],
+          |  "chargeTypesExcluded" : false
+          |}
+          |""".stripMargin)
         .as[JsObject]
 
       def chargeInfoResponseR1JsonFromProxy: JsObject = Json
@@ -393,56 +393,56 @@ object ChargeInfoTestData {
 
       def chargeInfoResponseR2JsonFromProxy: JsObject = chargeInfoResponseR1JsonFromProxy ++ Json
         .parse("""{
-                 |  "customerSignals": [
-                 |    {
-                 |      "signalType": "Rls",
-                 |      "signalValue": "signal value",
-                 |      "signalDescription": "description"
-                 |    },
-                 |    {
-                 |      "signalType": "Welsh Language Signal",
-                 |      "signalValue": "signal value",
-                 |      "signalDescription": "description"
-                 |    }
-                 |  ],
-                 |  "chargeTypeAssessment" : [
-                 |    {
-                 |      "chargeReference" : "CHARGE REFERENCE",
-                 |      "charges" : [
-                 |        {
-                 |          "accruedInterest" : 50,
-                 |          "chargeSource" : "Source",
-                 |          "chargeType" : "charge type",
-                 |          "creationDate" : "2025-07-02",
-                 |          "dueDate" : "2021-01-31",
-                 |          "interestStartDate" : "2020-01-03",
-                 |          "isInterestBearingCharge" : true,
-                 |          "mainType" : "main type",
-                 |          "originalChargeType" : "Original Charge Type",
-                 |          "outstandingAmount" : 500,
-                 |          "parentMainTrans" : "Parent Main Transaction",
-                 |          "saTaxYearEnd" : "2020-04-05",
-                 |          "subTrans" : "1000",
-                 |          "taxPeriodFrom" : "2020-01-02",
-                 |          "taxPeriodTo" : "2020-12-31",
-                 |          "tieBreaker" : "Tie Breaker",
-                 |          "locks": [
-                 |            {
-                 |              "lockType": "Posting/Clearing",
-                 |              "lockReason": "No Reallocation"
-                 |            }
-                 |          ]
-                 |        }
-                 |      ],
-                 |      "debtTotalAmount" : 1000,
-                 |      "mainTrans" : "2000",
-                 |      "parentChargeReference" : "PARENT CHARGE REF",
-                 |      "isInsolvent": false
-                 |    }
-                 |  ],
-                 |  "chargeTypesExcluded" : false
-                 |}
-                 |""".stripMargin)
+          |  "customerSignals": [
+          |    {
+          |      "signalType": "Rls",
+          |      "signalValue": "signal value",
+          |      "signalDescription": "description"
+          |    },
+          |    {
+          |      "signalType": "Welsh Language Signal",
+          |      "signalValue": "signal value",
+          |      "signalDescription": "description"
+          |    }
+          |  ],
+          |  "chargeTypeAssessment" : [
+          |    {
+          |      "chargeReference" : "CHARGE REFERENCE",
+          |      "charges" : [
+          |        {
+          |          "accruedInterest" : 50,
+          |          "chargeSource" : "Source",
+          |          "chargeType" : "charge type",
+          |          "creationDate" : "2025-07-02",
+          |          "dueDate" : "2021-01-31",
+          |          "interestStartDate" : "2020-01-03",
+          |          "isInterestBearingCharge" : true,
+          |          "mainType" : "main type",
+          |          "originalChargeType" : "Original Charge Type",
+          |          "outstandingAmount" : 500,
+          |          "parentMainTrans" : "Parent Main Transaction",
+          |          "saTaxYearEnd" : "2020-04-05",
+          |          "subTrans" : "1000",
+          |          "taxPeriodFrom" : "2020-01-02",
+          |          "taxPeriodTo" : "2020-12-31",
+          |          "tieBreaker" : "Tie Breaker",
+          |          "locks": [
+          |            {
+          |              "lockType": "Posting/Clearing",
+          |              "lockReason": "No Reallocation"
+          |            }
+          |          ]
+          |        }
+          |      ],
+          |      "debtTotalAmount" : 1000,
+          |      "mainTrans" : "2000",
+          |      "parentChargeReference" : "PARENT CHARGE REF",
+          |      "isInsolvent": false
+          |    }
+          |  ],
+          |  "chargeTypesExcluded" : false
+          |}
+          |""".stripMargin)
         .as[JsObject]
     }
 
@@ -672,49 +672,49 @@ object ChargeInfoTestData {
 
       def chargeInfoResponseR2JsonFromEligibility: JsObject = chargeInfoResponseR1JsonFromEligibility ++ Json
         .parse("""{
-                 |  "customerSignals": [
-                 |    {
-                 |      "signalType": "Welsh Language Signal",
-                 |      "signalValue": "signal value"
-                 |    }
-                 |  ],
-                 |  "chargeTypeAssessment" : [
-                 |    {
-                 |      "chargeReference" : "CHARGE REFERENCE",
-                 |      "charges" : [
-                 |        {
-                 |          "accruedInterest" : 50,
-                 |          "chargeSource" : "Source",
-                 |          "chargeType" : "charge type",
-                 |          "creationDate" : "2025-07-02",
-                 |          "dueDate" : "2021-01-31",
-                 |          "interestStartDate" : "2020-01-03",
-                 |          "isInterestBearingCharge" : true,
-                 |          "mainType" : "main type",
-                 |          "originalChargeType" : "Original Charge Type",
-                 |          "outstandingAmount" : 500,
-                 |          "parentMainTrans" : "Parent Main Transaction",
-                 |          "saTaxYearEnd" : "2020-04-05",
-                 |          "subTrans" : "1000",
-                 |          "taxPeriodFrom" : "2020-01-02",
-                 |          "taxPeriodTo" : "2020-12-31",
-                 |          "tieBreaker" : "Tie Breaker",
+          |  "customerSignals": [
+          |    {
+          |      "signalType": "Welsh Language Signal",
+          |      "signalValue": "signal value"
+          |    }
+          |  ],
+          |  "chargeTypeAssessment" : [
+          |    {
+          |      "chargeReference" : "CHARGE REFERENCE",
+          |      "charges" : [
+          |        {
+          |          "accruedInterest" : 50,
+          |          "chargeSource" : "Source",
+          |          "chargeType" : "charge type",
+          |          "creationDate" : "2025-07-02",
+          |          "dueDate" : "2021-01-31",
+          |          "interestStartDate" : "2020-01-03",
+          |          "isInterestBearingCharge" : true,
+          |          "mainType" : "main type",
+          |          "originalChargeType" : "Original Charge Type",
+          |          "outstandingAmount" : 500,
+          |          "parentMainTrans" : "Parent Main Transaction",
+          |          "saTaxYearEnd" : "2020-04-05",
+          |          "subTrans" : "1000",
+          |          "taxPeriodFrom" : "2020-01-02",
+          |          "taxPeriodTo" : "2020-12-31",
+          |          "tieBreaker" : "Tie Breaker",
                             "locks": [
-                 |            {
-                 |              "lockType": "Posting/Clearing",
-                 |              "lockReason": "No Reallocation"
-                 |            }
-                 |          ]
-                 |        }
-                 |      ],
-                 |      "debtTotalAmount" : 1000,
-                 |      "mainTrans" : "2000",
-                 |      "parentChargeReference" : "PARENT CHARGE REF",
-                 |      "isInsolvent": false
-                 |    }
-                 |  ],
-                 |  "chargeTypesExcluded": false
-                 |}""".stripMargin)
+          |            {
+          |              "lockType": "Posting/Clearing",
+          |              "lockReason": "No Reallocation"
+          |            }
+          |          ]
+          |        }
+          |      ],
+          |      "debtTotalAmount" : 1000,
+          |      "mainTrans" : "2000",
+          |      "parentChargeReference" : "PARENT CHARGE REF",
+          |      "isInsolvent": false
+          |    }
+          |  ],
+          |  "chargeTypesExcluded": false
+          |}""".stripMargin)
         .as[JsObject]
 
       def chargeInfoResponseR1JsonFromProxy: JsObject = Json
@@ -786,49 +786,49 @@ object ChargeInfoTestData {
 
       def chargeInfoResponseR2JsonFromProxy: JsObject = chargeInfoResponseR1JsonFromProxy ++ Json
         .parse("""{
-                 |  "customerSignals": [
-                 |    {
-                 |      "signalType": "Welsh Language Signal",
-                 |      "signalValue": "signal value"
-                 |    }
-                 |  ],
-                 |  "chargeTypeAssessment" : [
-                 |    {
-                 |      "chargeReference" : "CHARGE REFERENCE",
-                 |      "charges" : [
-                 |        {
-                 |          "accruedInterest" : 50,
-                 |          "chargeSource" : "Source",
-                 |          "chargeType" : "charge type",
-                 |          "creationDate" : "2025-07-02",
-                 |          "dueDate" : "2021-01-31",
-                 |          "interestStartDate" : "2020-01-03",
-                 |          "isInterestBearingCharge" : true,
-                 |          "mainType" : "main type",
-                 |          "originalChargeType" : "Original Charge Type",
-                 |          "outstandingAmount" : 500,
-                 |          "parentMainTrans" : "Parent Main Transaction",
-                 |          "saTaxYearEnd" : "2020-04-05",
-                 |          "subTrans" : "1000",
-                 |          "taxPeriodFrom" : "2020-01-02",
-                 |          "taxPeriodTo" : "2020-12-31",
-                 |          "tieBreaker" : "Tie Breaker",
+          |  "customerSignals": [
+          |    {
+          |      "signalType": "Welsh Language Signal",
+          |      "signalValue": "signal value"
+          |    }
+          |  ],
+          |  "chargeTypeAssessment" : [
+          |    {
+          |      "chargeReference" : "CHARGE REFERENCE",
+          |      "charges" : [
+          |        {
+          |          "accruedInterest" : 50,
+          |          "chargeSource" : "Source",
+          |          "chargeType" : "charge type",
+          |          "creationDate" : "2025-07-02",
+          |          "dueDate" : "2021-01-31",
+          |          "interestStartDate" : "2020-01-03",
+          |          "isInterestBearingCharge" : true,
+          |          "mainType" : "main type",
+          |          "originalChargeType" : "Original Charge Type",
+          |          "outstandingAmount" : 500,
+          |          "parentMainTrans" : "Parent Main Transaction",
+          |          "saTaxYearEnd" : "2020-04-05",
+          |          "subTrans" : "1000",
+          |          "taxPeriodFrom" : "2020-01-02",
+          |          "taxPeriodTo" : "2020-12-31",
+          |          "tieBreaker" : "Tie Breaker",
                             "locks": [
-                 |            {
-                 |              "lockType": "Posting/Clearing",
-                 |              "lockReason": "No Reallocation"
-                 |            }
-                 |          ]
-                 |        }
-                 |      ],
-                 |      "debtTotalAmount" : 1000,
-                 |      "mainTrans" : "2000",
-                 |      "parentChargeReference" : "PARENT CHARGE REF",
-                 |      "isInsolvent": false
-                 |    }
-                 |  ],
-                 |  "chargeTypesExcluded": false
-                 |}""".stripMargin)
+          |            {
+          |              "lockType": "Posting/Clearing",
+          |              "lockReason": "No Reallocation"
+          |            }
+          |          ]
+          |        }
+          |      ],
+          |      "debtTotalAmount" : 1000,
+          |      "mainTrans" : "2000",
+          |      "parentChargeReference" : "PARENT CHARGE REF",
+          |      "isInsolvent": false
+          |    }
+          |  ],
+          |  "chargeTypesExcluded": false
+          |}""".stripMargin)
         .as[JsObject]
     }
 
@@ -1022,35 +1022,35 @@ object ChargeInfoTestData {
 
       def chargeInfoResponseR2JsonFromEligibility: JsObject = chargeInfoResponseR1JsonFromEligibility ++ Json
         .parse("""{
-                 |  "customerSignals": [
-                 |    {
-                 |      "signalType": "Welsh Language Signal",
-                 |      "signalValue": "signal value"
-                 |    }
-                 |  ],
-                 |  "chargeTypeAssessment" : [
-                 |    {
-                 |      "chargeReference" : "CHARGE REFERENCE",
-                 |      "charges" : [
-                 |        {
-                 |          "accruedInterest" : 50,
-                 |          "chargeSource" : "Source",
-                 |          "chargeType" : "charge type",
-                 |          "dueDate" : "2021-01-31",
-                 |          "mainType" : "main type",
-                 |          "outstandingAmount" : 500,
-                 |          "subTrans" : "1000",
-                 |          "taxPeriodFrom" : "2020-01-02",
-                 |          "taxPeriodTo" : "2020-12-31"
-                 |        }
-                 |      ],
-                 |      "debtTotalAmount" : 1000,
-                 |      "mainTrans" : "2000",
-                 |      "isInsolvent": false
-                 |    }
-                 |  ],
-                 |  "chargeTypesExcluded" : false
-                 |}""".stripMargin)
+          |  "customerSignals": [
+          |    {
+          |      "signalType": "Welsh Language Signal",
+          |      "signalValue": "signal value"
+          |    }
+          |  ],
+          |  "chargeTypeAssessment" : [
+          |    {
+          |      "chargeReference" : "CHARGE REFERENCE",
+          |      "charges" : [
+          |        {
+          |          "accruedInterest" : 50,
+          |          "chargeSource" : "Source",
+          |          "chargeType" : "charge type",
+          |          "dueDate" : "2021-01-31",
+          |          "mainType" : "main type",
+          |          "outstandingAmount" : 500,
+          |          "subTrans" : "1000",
+          |          "taxPeriodFrom" : "2020-01-02",
+          |          "taxPeriodTo" : "2020-12-31"
+          |        }
+          |      ],
+          |      "debtTotalAmount" : 1000,
+          |      "mainTrans" : "2000",
+          |      "isInsolvent": false
+          |    }
+          |  ],
+          |  "chargeTypesExcluded" : false
+          |}""".stripMargin)
         .as[JsObject]
 
       def chargeInfoResponseR1JsonFromProxy: JsObject = Json
@@ -1106,35 +1106,35 @@ object ChargeInfoTestData {
 
       def chargeInfoResponseR2JsonFromProxy: JsObject = chargeInfoResponseR1JsonFromProxy ++ Json
         .parse("""{
-                 |  "customerSignals": [
-                 |    {
-                 |      "signalType": "Welsh Language Signal",
-                 |      "signalValue": "signal value"
-                 |    }
-                 |  ],
-                 |  "chargeTypeAssessment" : [
-                 |    {
-                 |      "chargeReference" : "CHARGE REFERENCE",
-                 |      "charges" : [
-                 |        {
-                 |          "accruedInterest" : 50,
-                 |          "chargeSource" : "Source",
-                 |          "chargeType" : "charge type",
-                 |          "dueDate" : "2021-01-31",
-                 |          "mainType" : "main type",
-                 |          "outstandingAmount" : 500,
-                 |          "subTrans" : "1000",
-                 |          "taxPeriodFrom" : "2020-01-02",
-                 |          "taxPeriodTo" : "2020-12-31"
-                 |        }
-                 |      ],
-                 |      "debtTotalAmount" : 1000,
-                 |      "mainTrans" : "2000",
-                 |      "isInsolvent": false
-                 |    }
-                 |  ],
-                 |  "chargeTypesExcluded": false
-                 |}""".stripMargin)
+          |  "customerSignals": [
+          |    {
+          |      "signalType": "Welsh Language Signal",
+          |      "signalValue": "signal value"
+          |    }
+          |  ],
+          |  "chargeTypeAssessment" : [
+          |    {
+          |      "chargeReference" : "CHARGE REFERENCE",
+          |      "charges" : [
+          |        {
+          |          "accruedInterest" : 50,
+          |          "chargeSource" : "Source",
+          |          "chargeType" : "charge type",
+          |          "dueDate" : "2021-01-31",
+          |          "mainType" : "main type",
+          |          "outstandingAmount" : 500,
+          |          "subTrans" : "1000",
+          |          "taxPeriodFrom" : "2020-01-02",
+          |          "taxPeriodTo" : "2020-12-31"
+          |        }
+          |      ],
+          |      "debtTotalAmount" : 1000,
+          |      "mainTrans" : "2000",
+          |      "isInsolvent": false
+          |    }
+          |  ],
+          |  "chargeTypesExcluded": false
+          |}""".stripMargin)
         .as[JsObject]
     }
   }

--- a/test/uk/gov/hmrc/timetopayproxy/models/saonly/common/DdiReferenceSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/models/saonly/common/DdiReferenceSpec.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.timetopayproxy.models.saonly.common
 
 import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers._
+import org.scalatest.matchers.should.Matchers.*
 import play.api.libs.json.{ JsNumber, JsResultException, JsString, Json }
 
 class DdiReferenceSpec extends AnyFreeSpec {

--- a/test/uk/gov/hmrc/timetopayproxy/models/saonly/common/NonEmptyListFormatSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/models/saonly/common/NonEmptyListFormatSpec.scala
@@ -18,8 +18,8 @@ package uk.gov.hmrc.timetopayproxy.models.saonly.common
 
 import cats.data.NonEmptyList
 import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
-import play.api.libs.json._
+import org.scalatest.matchers.should.Matchers.shouldBe
+import play.api.libs.json.*
 
 final case class NelInts(values: NonEmptyList[Int])
 

--- a/test/uk/gov/hmrc/timetopayproxy/models/saonly/common/SaOnlyPaymentPlanSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/models/saonly/common/SaOnlyPaymentPlanSpec.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.timetopayproxy.models.saonly.common
 
 import cats.data.NonEmptyList
 import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers._
+import org.scalatest.matchers.should.Matchers.*
 import play.api.libs.json.{ JsNumber, JsResultException, Json }
 import uk.gov.hmrc.timetopayproxy.models.{ DebtItemChargeId, FrequencyLowercase }
 import uk.gov.hmrc.timetopayproxy.models.currency.GbpPounds

--- a/test/uk/gov/hmrc/timetopayproxy/models/saonly/ttpcancel/TtpCancelInformativeErrorSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/models/saonly/ttpcancel/TtpCancelInformativeErrorSpec.scala
@@ -17,11 +17,11 @@
 package uk.gov.hmrc.timetopayproxy.models.saonly.ttpcancel
 
 import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers._
+import org.scalatest.matchers.should.Matchers.*
 import play.api.libs.json.{ JsSuccess, JsValue, Json, Reads, Writes }
 import uk.gov.hmrc.timetopayproxy.models.saonly.common.ProcessingDateTimeInstant
 import uk.gov.hmrc.timetopayproxy.models.saonly.common.apistatus.{ ApiErrorResponse, ApiName, ApiStatus, ApiStatusCode }
-import uk.gov.hmrc.timetopayproxy.testutils.JsonAssertionOps._
+import uk.gov.hmrc.timetopayproxy.testutils.JsonAssertionOps.*
 import uk.gov.hmrc.timetopayproxy.testutils.schematestutils.Validators
 import uk.gov.hmrc.timetopayproxy.testutils.schematestutils.Validators.TimeToPayProxy.TtpCancel.Live
 

--- a/test/uk/gov/hmrc/timetopayproxy/models/saonly/ttpcancel/TtpCancelRequestR2Spec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/models/saonly/ttpcancel/TtpCancelRequestR2Spec.scala
@@ -18,11 +18,11 @@ package uk.gov.hmrc.timetopayproxy.models.saonly.ttpcancel
 
 import cats.data.NonEmptyList
 import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
-import play.api.libs.json._
-import uk.gov.hmrc.timetopayproxy.models._
+import org.scalatest.matchers.should.Matchers.shouldBe
+import play.api.libs.json.*
+import uk.gov.hmrc.timetopayproxy.models.*
 import uk.gov.hmrc.timetopayproxy.models.currency.GbpPounds
-import uk.gov.hmrc.timetopayproxy.models.saonly.common._
+import uk.gov.hmrc.timetopayproxy.models.saonly.common.*
 import uk.gov.hmrc.timetopayproxy.testutils.schematestutils.Validators.TimeToPayProxy.TtpCancel.Proposed
 
 import java.time.LocalDate
@@ -269,50 +269,50 @@ class TtpCancelRequestR2Spec extends AnyFreeSpec {
       "should throw an error" - {
         "when trying to parse an invalid frequency and channelIdentifier" in {
           val cancelRequestJson = Json.parse("""
-                                               |{
-                                               |  "identifications": [
-                                               |    {
-                                               |      "idType": "UTR",
-                                               |      "idValue": "1234567890"
-                                               |    }
-                                               |  ],
-                                               |  "paymentPlan": {
-                                               |    "arrangementAgreedDate": "2025-05-01",
-                                               |    "ttpEndDate": "2025-11-01",
-                                               |    "initialPaymentDate": "2025-05-05",
-                                               |    "initialPaymentAmount": 150,
-                                               |    "frequency": "TEST",
-                                               |    "cancellationDate": "2025-10-15",
-                                               |    "debtItemCharges": [
-                                               |      {
-                                               |        "debtItemChargeId": "K0000000000001",
-                                               |        "chargeSource": "CESA"
-                                               |      }
-                                               |    ]
-                                               |  },
-                                               |  "instalments": [
-                                               |    {
-                                               |      "dueDate": "2025-06-01",
-                                               |      "amountDue": 300
-                                               |    },
-                                               |    {
-                                               |      "dueDate": "2025-07-01",
-                                               |      "amountDue": 300
-                                               |    },
-                                               |    {
-                                               |      "dueDate": "2025-08-01",
-                                               |      "amountDue": 300
-                                               |    }
-                                               |  ],
-                                               |  "channelIdentifier": "TEST",
-                                               |  "transitioned": true
-                                               |}
-                                               |""".stripMargin)
+            |{
+            |  "identifications": [
+            |    {
+            |      "idType": "UTR",
+            |      "idValue": "1234567890"
+            |    }
+            |  ],
+            |  "paymentPlan": {
+            |    "arrangementAgreedDate": "2025-05-01",
+            |    "ttpEndDate": "2025-11-01",
+            |    "initialPaymentDate": "2025-05-05",
+            |    "initialPaymentAmount": 150,
+            |    "frequency": "TEST",
+            |    "cancellationDate": "2025-10-15",
+            |    "debtItemCharges": [
+            |      {
+            |        "debtItemChargeId": "K0000000000001",
+            |        "chargeSource": "CESA"
+            |      }
+            |    ]
+            |  },
+            |  "instalments": [
+            |    {
+            |      "dueDate": "2025-06-01",
+            |      "amountDue": 300
+            |    },
+            |    {
+            |      "dueDate": "2025-07-01",
+            |      "amountDue": 300
+            |    },
+            |    {
+            |      "dueDate": "2025-08-01",
+            |      "amountDue": 300
+            |    }
+            |  ],
+            |  "channelIdentifier": "TEST",
+            |  "transitioned": true
+            |}
+            |""".stripMargin)
 
           readerFromClients.reads(cancelRequestJson) shouldBe JsError(
             List(
               (
-                JsPath \ "paymentPlan" \ "frequency",
+                JsPath \ "channelIdentifier",
                 List(
                   JsonValidationError(
                     List("error.expected.validenumvalue")
@@ -320,7 +320,7 @@ class TtpCancelRequestR2Spec extends AnyFreeSpec {
                 )
               ),
               (
-                JsPath \ "channelIdentifier",
+                JsPath \ "paymentPlan" \ "frequency",
                 List(
                   JsonValidationError(
                     List("error.expected.validenumvalue")
@@ -333,39 +333,39 @@ class TtpCancelRequestR2Spec extends AnyFreeSpec {
 
         "when a mandatory field, debtItemCharges, is missing " in {
           val cancelRequestJson = Json.parse("""
-                                               |{
-                                               |  "identifications": [
-                                               |    {
-                                               |      "idType": "UTR",
-                                               |      "idValue": "1234567890"
-                                               |    }
-                                               |  ],
-                                               |  "paymentPlan": {
-                                               |    "arrangementAgreedDate": "2025-05-01",
-                                               |    "ttpEndDate": "2025-11-01",
-                                               |    "initialPaymentDate": "2025-05-05",
-                                               |    "initialPaymentAmount": 150,
-                                               |    "frequency": "monthly",
-                                               |    "cancellationDate": "2025-10-15"
-                                               |  },
-                                               |  "instalments": [
-                                               |    {
-                                               |      "dueDate": "2025-06-01",
-                                               |      "amountDue": 300
-                                               |    },
-                                               |    {
-                                               |      "dueDate": "2025-07-01",
-                                               |      "amountDue": 300
-                                               |    },
-                                               |    {
-                                               |      "dueDate": "2025-08-01",
-                                               |      "amountDue": 300
-                                               |    }
-                                               |  ],
-                                               |  "channelIdentifier": "advisor",
-                                               |  "transitioned": true
-                                               |}
-                                               |""".stripMargin)
+            |{
+            |  "identifications": [
+            |    {
+            |      "idType": "UTR",
+            |      "idValue": "1234567890"
+            |    }
+            |  ],
+            |  "paymentPlan": {
+            |    "arrangementAgreedDate": "2025-05-01",
+            |    "ttpEndDate": "2025-11-01",
+            |    "initialPaymentDate": "2025-05-05",
+            |    "initialPaymentAmount": 150,
+            |    "frequency": "monthly",
+            |    "cancellationDate": "2025-10-15"
+            |  },
+            |  "instalments": [
+            |    {
+            |      "dueDate": "2025-06-01",
+            |      "amountDue": 300
+            |    },
+            |    {
+            |      "dueDate": "2025-07-01",
+            |      "amountDue": 300
+            |    },
+            |    {
+            |      "dueDate": "2025-08-01",
+            |      "amountDue": 300
+            |    }
+            |  ],
+            |  "channelIdentifier": "advisor",
+            |  "transitioned": true
+            |}
+            |""".stripMargin)
 
           readerFromClients.reads(cancelRequestJson) shouldBe JsError(
             List(

--- a/test/uk/gov/hmrc/timetopayproxy/models/saonly/ttpcancel/TtpCancelRequestSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/models/saonly/ttpcancel/TtpCancelRequestSpec.scala
@@ -18,12 +18,12 @@ package uk.gov.hmrc.timetopayproxy.models.saonly.ttpcancel
 
 import cats.data.NonEmptyList
 import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers._
-import play.api.libs.json._
-import uk.gov.hmrc.timetopayproxy.models._
+import org.scalatest.matchers.should.Matchers.*
+import play.api.libs.json.*
+import uk.gov.hmrc.timetopayproxy.models.*
 import uk.gov.hmrc.timetopayproxy.models.currency.GbpPounds
-import uk.gov.hmrc.timetopayproxy.models.saonly.common._
-import uk.gov.hmrc.timetopayproxy.testutils.JsonAssertionOps._
+import uk.gov.hmrc.timetopayproxy.models.saonly.common.*
+import uk.gov.hmrc.timetopayproxy.testutils.JsonAssertionOps.*
 import uk.gov.hmrc.timetopayproxy.testutils.schematestutils.Validators
 import uk.gov.hmrc.timetopayproxy.testutils.schematestutils.Validators.TimeToPayProxy.TtpCancel.Live
 

--- a/test/uk/gov/hmrc/timetopayproxy/models/saonly/ttpcancel/TtpCancelSuccessfulResponseSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/models/saonly/ttpcancel/TtpCancelSuccessfulResponseSpec.scala
@@ -17,11 +17,11 @@
 package uk.gov.hmrc.timetopayproxy.models.saonly.ttpcancel
 
 import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers._
-import play.api.libs.json._
+import org.scalatest.matchers.should.Matchers.*
+import play.api.libs.json.*
 import uk.gov.hmrc.timetopayproxy.models.saonly.common.ProcessingDateTimeInstant
 import uk.gov.hmrc.timetopayproxy.models.saonly.common.apistatus.{ ApiErrorResponse, ApiName, ApiStatus, ApiStatusCode }
-import uk.gov.hmrc.timetopayproxy.testutils.JsonAssertionOps._
+import uk.gov.hmrc.timetopayproxy.testutils.JsonAssertionOps.*
 import uk.gov.hmrc.timetopayproxy.testutils.schematestutils.Validators
 import uk.gov.hmrc.timetopayproxy.testutils.schematestutils.Validators.TimeToPayProxy.TtpCancel.Live
 

--- a/test/uk/gov/hmrc/timetopayproxy/models/saonly/ttpfullamend/TtpFullAmendInformativeErrorSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/models/saonly/ttpfullamend/TtpFullAmendInformativeErrorSpec.scala
@@ -17,11 +17,11 @@
 package uk.gov.hmrc.timetopayproxy.models.saonly.ttpfullamend
 
 import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers._
-import play.api.libs.json._
+import org.scalatest.matchers.should.Matchers.*
+import play.api.libs.json.*
 import uk.gov.hmrc.timetopayproxy.models.saonly.common.ProcessingDateTimeInstant
 import uk.gov.hmrc.timetopayproxy.models.saonly.common.apistatus.{ ApiErrorResponse, ApiName, ApiStatus, ApiStatusCode }
-import uk.gov.hmrc.timetopayproxy.testutils.JsonAssertionOps._
+import uk.gov.hmrc.timetopayproxy.testutils.JsonAssertionOps.*
 import uk.gov.hmrc.timetopayproxy.testutils.schematestutils.Validators
 
 import java.time.Instant

--- a/test/uk/gov/hmrc/timetopayproxy/models/saonly/ttpfullamend/TtpFullAmendRequestSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/models/saonly/ttpfullamend/TtpFullAmendRequestSpec.scala
@@ -19,13 +19,13 @@ package uk.gov.hmrc.timetopayproxy.models.saonly.ttpfullamend
 import cats.data.NonEmptyList
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers._
-import play.api.libs.json._
+import org.scalatest.matchers.should.Matchers.*
+import play.api.libs.json.*
 import uk.gov.hmrc.timetopayproxy.config.FeatureSwitch
-import uk.gov.hmrc.timetopayproxy.models._
+import uk.gov.hmrc.timetopayproxy.models.*
 import uk.gov.hmrc.timetopayproxy.models.currency.GbpPounds
-import uk.gov.hmrc.timetopayproxy.models.saonly.common._
-import uk.gov.hmrc.timetopayproxy.testutils.JsonAssertionOps._
+import uk.gov.hmrc.timetopayproxy.models.saonly.common.*
+import uk.gov.hmrc.timetopayproxy.testutils.JsonAssertionOps.*
 import uk.gov.hmrc.timetopayproxy.testutils.schematestutils.Validators
 
 import java.time.LocalDate

--- a/test/uk/gov/hmrc/timetopayproxy/models/saonly/ttpfullamend/TtpFullAmendSuccessfulResponseSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/models/saonly/ttpfullamend/TtpFullAmendSuccessfulResponseSpec.scala
@@ -17,11 +17,11 @@
 package uk.gov.hmrc.timetopayproxy.models.saonly.ttpfullamend
 
 import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers._
-import play.api.libs.json._
+import org.scalatest.matchers.should.Matchers.*
+import play.api.libs.json.*
 import uk.gov.hmrc.timetopayproxy.models.saonly.common.ProcessingDateTimeInstant
 import uk.gov.hmrc.timetopayproxy.models.saonly.common.apistatus.{ ApiErrorResponse, ApiName, ApiStatus, ApiStatusCode }
-import uk.gov.hmrc.timetopayproxy.testutils.JsonAssertionOps._
+import uk.gov.hmrc.timetopayproxy.testutils.JsonAssertionOps.*
 import uk.gov.hmrc.timetopayproxy.testutils.schematestutils.Validators
 
 import java.time.Instant

--- a/test/uk/gov/hmrc/timetopayproxy/models/saonly/ttpinform/TtpInformInformativeErrorSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/models/saonly/ttpinform/TtpInformInformativeErrorSpec.scala
@@ -17,11 +17,11 @@
 package uk.gov.hmrc.timetopayproxy.models.saonly.ttpinform
 
 import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers._
-import play.api.libs.json._
+import org.scalatest.matchers.should.Matchers.*
+import play.api.libs.json.*
 import uk.gov.hmrc.timetopayproxy.models.saonly.common.ProcessingDateTimeInstant
 import uk.gov.hmrc.timetopayproxy.models.saonly.common.apistatus.{ ApiErrorResponse, ApiName, ApiStatus, ApiStatusCode }
-import uk.gov.hmrc.timetopayproxy.testutils.JsonAssertionOps._
+import uk.gov.hmrc.timetopayproxy.testutils.JsonAssertionOps.*
 import uk.gov.hmrc.timetopayproxy.testutils.schematestutils.Validators
 
 import java.time.Instant

--- a/test/uk/gov/hmrc/timetopayproxy/models/saonly/ttpinform/TtpInformRequestSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/models/saonly/ttpinform/TtpInformRequestSpec.scala
@@ -19,12 +19,12 @@ package uk.gov.hmrc.timetopayproxy.models.saonly.ttpinform
 import cats.data.NonEmptyList
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers._
-import play.api.libs.json._
-import uk.gov.hmrc.timetopayproxy.models._
+import org.scalatest.matchers.should.Matchers.*
+import play.api.libs.json.*
+import uk.gov.hmrc.timetopayproxy.models.*
 import uk.gov.hmrc.timetopayproxy.models.currency.GbpPounds
-import uk.gov.hmrc.timetopayproxy.models.saonly.common._
-import uk.gov.hmrc.timetopayproxy.testutils.JsonAssertionOps._
+import uk.gov.hmrc.timetopayproxy.models.saonly.common.*
+import uk.gov.hmrc.timetopayproxy.testutils.JsonAssertionOps.*
 import uk.gov.hmrc.timetopayproxy.testutils.schematestutils.Validators
 
 import java.time.LocalDate

--- a/test/uk/gov/hmrc/timetopayproxy/models/saonly/ttpinform/TtpInformSuccessfulResponseSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/models/saonly/ttpinform/TtpInformSuccessfulResponseSpec.scala
@@ -17,11 +17,11 @@
 package uk.gov.hmrc.timetopayproxy.models.saonly.ttpinform
 
 import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers._
-import play.api.libs.json._
+import org.scalatest.matchers.should.Matchers.*
+import play.api.libs.json.*
 import uk.gov.hmrc.timetopayproxy.models.saonly.common.ProcessingDateTimeInstant
 import uk.gov.hmrc.timetopayproxy.models.saonly.common.apistatus.{ ApiErrorResponse, ApiName, ApiStatus, ApiStatusCode }
-import uk.gov.hmrc.timetopayproxy.testutils.JsonAssertionOps._
+import uk.gov.hmrc.timetopayproxy.testutils.JsonAssertionOps.*
 import uk.gov.hmrc.timetopayproxy.testutils.schematestutils.Validators
 
 import java.time.Instant

--- a/test/uk/gov/hmrc/timetopayproxy/services/TTPEServiceSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/services/TTPEServiceSpec.scala
@@ -21,13 +21,13 @@ import cats.implicits.catsSyntaxEitherId
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.Inside.inside
 import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers._
+import org.scalatest.matchers.should.Matchers.*
 import play.api.test.Helpers.{ await, defaultAwaitTimeout }
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.timetopayproxy.connectors.TtpeConnector
 import uk.gov.hmrc.timetopayproxy.models.error.TtppEnvelope.TtppEnvelope
 import uk.gov.hmrc.timetopayproxy.models.error.{ ConnectorError, ProxyEnvelopeError, TtppEnvelope }
-import uk.gov.hmrc.timetopayproxy.models.saonly.chargeInfoApi._
+import uk.gov.hmrc.timetopayproxy.models.saonly.chargeInfoApi.*
 import uk.gov.hmrc.timetopayproxy.models.saonly.common.SaOnlyRegimeType
 import uk.gov.hmrc.timetopayproxy.models.{ ChargeTypesExcluded, IdType, IdValue, Identification }
 

--- a/test/uk/gov/hmrc/timetopayproxy/services/TTPQuoteServiceSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/services/TTPQuoteServiceSpec.scala
@@ -16,10 +16,10 @@
 
 package uk.gov.hmrc.timetopayproxy.services
 
-import cats.syntax.either._
+import cats.syntax.either.*
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.timetopayproxy.connectors.TtpConnector
-import uk.gov.hmrc.timetopayproxy.models._
+import uk.gov.hmrc.timetopayproxy.models.*
 import uk.gov.hmrc.timetopayproxy.models.affordablequotes.{ AffordableQuoteResponse, AffordableQuotesRequest }
 import uk.gov.hmrc.timetopayproxy.models.error.TtppEnvelope.TtppEnvelope
 import uk.gov.hmrc.timetopayproxy.models.error.{ ConnectorError, ProxyEnvelopeError, TtppEnvelope }
@@ -342,7 +342,7 @@ class TTPQuoteServiceSpec extends UnitSpec {
         PaymentMethod.OnGoingAward
       )
 
-      paymentMethods.foreach { paymentMethod: PaymentMethod =>
+      paymentMethods.foreach { paymentMethod =>
         val retrievePlanWithPaymentInfo =
           retrievePlanResponse.copy(payments = List(PaymentInformation(paymentMethod, Some(paymentReference))))
 

--- a/test/uk/gov/hmrc/timetopayproxy/services/TTPTestServiceSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/services/TTPTestServiceSpec.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.timetopayproxy.services
 
-import cats.syntax.either._
+import cats.syntax.either.*
 import play.api.libs.json.Json
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.timetopayproxy.connectors.TtpTestConnector

--- a/test/uk/gov/hmrc/timetopayproxy/services/TtpFeedbackLoopServiceSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/services/TtpFeedbackLoopServiceSpec.scala
@@ -17,17 +17,17 @@
 package uk.gov.hmrc.timetopayproxy.services
 
 import cats.data.NonEmptyList
-import cats.syntax.either._
+import cats.syntax.either.*
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers._
+import org.scalatest.matchers.should.Matchers.*
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.timetopayproxy.connectors.TtpFeedbackLoopConnector
-import uk.gov.hmrc.timetopayproxy.models._
+import uk.gov.hmrc.timetopayproxy.models.*
 import uk.gov.hmrc.timetopayproxy.models.currency.GbpPounds
 import uk.gov.hmrc.timetopayproxy.models.error.{ ConnectorError, TtppEnvelope }
-import uk.gov.hmrc.timetopayproxy.models.saonly.common._
+import uk.gov.hmrc.timetopayproxy.models.saonly.common.*
 import uk.gov.hmrc.timetopayproxy.models.saonly.common.apistatus.{ ApiName, ApiStatus, ApiStatusCode }
 import uk.gov.hmrc.timetopayproxy.models.saonly.ttpcancel.{ CancellationDate, TtpCancelPaymentPlan, TtpCancelPaymentPlanR2, TtpCancelRequest, TtpCancelRequestR2, TtpCancelSuccessfulResponse }
 import uk.gov.hmrc.timetopayproxy.models.saonly.ttpfullamend.{ ChargeAmendment, FullAmendRequest, NewDebtItemChargeReference, NewPaymentPlan, OriginalPaymentPlan, TtpFullAmendSuccessfulResponse }

--- a/test/uk/gov/hmrc/timetopayproxy/services/UpdatePlanServiceSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/services/UpdatePlanServiceSpec.scala
@@ -16,10 +16,10 @@
 
 package uk.gov.hmrc.timetopayproxy.services
 
-import cats.syntax.either._
+import cats.syntax.either.*
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.timetopayproxy.connectors.TtpConnector
-import uk.gov.hmrc.timetopayproxy.models._
+import uk.gov.hmrc.timetopayproxy.models.*
 import uk.gov.hmrc.timetopayproxy.models.error.{ ConnectorError, ProxyEnvelopeError, TtppEnvelope }
 import uk.gov.hmrc.timetopayproxy.support.UnitSpec
 

--- a/test/uk/gov/hmrc/timetopayproxy/support/WireMockUtils.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/support/WireMockUtils.scala
@@ -24,7 +24,7 @@ package uk.gov.hmrc.timetopayproxy.support
 import com.codahale.metrics.SharedMetricRegistries
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock
-import com.github.tomakehurst.wiremock.client.WireMock._
+import com.github.tomakehurst.wiremock.client.WireMock.*
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import org.scalatest.{ BeforeAndAfterAll, BeforeAndAfterEach }
@@ -41,7 +41,7 @@ trait WireMockUtils extends BeforeAndAfterEach with BeforeAndAfterAll with Guice
   val wireMockServer: WireMockServer = new WireMockServer(wireMockConfig().port(wireMockPort))
 
   override implicit lazy val app: Application = GuiceApplicationBuilder()
-    .configure("auditing.enabled" -> "false")
+    .configure("auditing.enabled" -> "false", "metrics.enabled" -> "false")
     .build()
 
   override def beforeAll(): Unit = {

--- a/test/uk/gov/hmrc/timetopayproxy/testutils/JsonAssertionOps.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/testutils/JsonAssertionOps.scala
@@ -20,10 +20,11 @@ import cats.data.NonEmptyList
 import com.fasterxml.jackson.core.util.{ DefaultIndenter, DefaultPrettyPrinter }
 import com.fasterxml.jackson.databind.{ ObjectMapper, SerializationFeature }
 import org.scalactic.source.Position
-import org.scalatest.matchers.should.Matchers._
-import play.api.libs.json._
+import org.scalatest.matchers.should.Matchers.*
+import play.api.libs.json.*
 import play.api.libs.json.jackson.PlayJsonMapperModule
 
+import scala.annotation.unused
 import scala.collection.immutable.SortedMap
 
 object JsonAssertionOps {
@@ -39,7 +40,7 @@ object JsonAssertionOps {
       * uk.gov.hmrc.timetopay.testutils.JsonAssertionOps.* // ... myJsValue1 shouldBeEquivalentTo myJsValue2 // Same as
       * you would use `shouldBe`. </pre> </li>
       */
-    def shouldBeEquivalentTo(other: JsValue)(implicit pos: Position): Unit =
+    infix def shouldBeEquivalentTo(other: JsValue)(implicit @unused pos: Position): Unit =
       if (json != other) {
         val diffableJson1 = json.diffableString + "\n"
         val diffableJson2 = other.diffableString + "\n"
@@ -61,7 +62,7 @@ object JsonAssertionOps {
         case _: JsNumber       => json
         case _: JsString       => json
         case JsArray(children) => JsArray(children.map(_.sortedFields))
-        case JsObject(fields) =>
+        case JsObject(fields)  =>
           JsObject(SortedMap.from(fields.view.mapValues(_.sortedFields)))
       }
   }
@@ -113,7 +114,7 @@ object JsonAssertionOps {
       * Note that this logic is not appropriate for production code. Here we need to throw in order to fail incorrect
       * tests, but production code would use ValidatedNel.
       */
-    def strictDeepMerge(mainJson2: JsValue)(implicit pos: Position): JsValue = {
+    def strictDeepMerge(mainJson2: JsValue)(implicit @unused pos: Position): JsValue = {
 
       def recursive(json1: JsValue, json2: JsValue, path: JsPath): JsValue =
         (json1, json2) match {

--- a/test/uk/gov/hmrc/timetopayproxy/testutils/JsonAssertionOpsSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/testutils/JsonAssertionOpsSpec.scala
@@ -18,8 +18,8 @@ package uk.gov.hmrc.timetopayproxy.testutils
 
 import org.scalatest.exceptions.TestFailedException
 import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers._
-import play.api.libs.json._
+import org.scalatest.matchers.should.Matchers.*
+import play.api.libs.json.*
 
 final class JsonAssertionOpsSpec extends AnyFreeSpec {
   "JsonAssertionOps" - {
@@ -42,9 +42,8 @@ final class JsonAssertionOpsSpec extends AnyFreeSpec {
           )
 
           for ((value1, value2) <- cases)
-            s"for $value1 and $value2" in {
+            s"for $value1 and $value2" in
               value1.shouldBeEquivalentTo(value2)
-            }
         }
 
         "for two different simple JSON values" - {
@@ -105,35 +104,35 @@ final class JsonAssertionOpsSpec extends AnyFreeSpec {
           // Mind the sorting of the object fields! (for determinism and easier JSON test maintenance)
           exception.getMessage() shouldBe
             s"""{
-               |  "field1" : [
-               |    "abc",
-               |    1,
-               |    false,
-               |    null,
-               |    true,
-               |    {
-               |      "field1" : "value",
-               |      "field2" : "value"
-               |    }
-               |  ],
-               |  "field2" : [
-               |    "def"
-               |  ],
-               |  "field3" : [
-               |    {
-               |      "field1" : "value"
-               |    },
-               |    {
-               |      "field2" : "value"
-               |    }
-               |  ]
-               |}
-               | was not equal to {
-               |  "field1" : [
-               |    "abc"
-               |  ]
-               |}
-               |""".stripMargin
+              |  "field1" : [
+              |    "abc",
+              |    1,
+              |    false,
+              |    null,
+              |    true,
+              |    {
+              |      "field1" : "value",
+              |      "field2" : "value"
+              |    }
+              |  ],
+              |  "field2" : [
+              |    "def"
+              |  ],
+              |  "field3" : [
+              |    {
+              |      "field1" : "value"
+              |    },
+              |    {
+              |      "field2" : "value"
+              |    }
+              |  ]
+              |}
+              | was not equal to {
+              |  "field1" : [
+              |    "abc"
+              |  ]
+              |}
+              |""".stripMargin
         }
       }
     }

--- a/test/uk/gov/hmrc/timetopayproxy/testutils/schematestutils/impl/DebtTransSchemaValidator.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/testutils/schematestutils/impl/DebtTransSchemaValidator.scala
@@ -24,12 +24,13 @@ import com.networknt.schema.{ Schema, SchemaRegistry, SchemaRegistryConfig, Spec
 import com.networknt.schema.regex.JDKRegularExpressionFactory
 import org.scalactic.source.Position
 import org.scalatest.Assertions.fail
-import org.scalatest.matchers.should.Matchers._
+import org.scalatest.matchers.should.Matchers.*
 import play.api.libs.json.{ JsString, JsValue }
 
 import java.util.Locale
+import scala.annotation.unused
 import scala.io.Source
-import scala.jdk.CollectionConverters._
+import scala.jdk.CollectionConverters.*
 import scala.util.Using
 
 /** Provides a JSON schema for validating JSON requests/responses. See the companion for the predefined instances. */
@@ -75,7 +76,7 @@ object DebtTransSchemaValidator {
 
     /** Constructing this class will automatically verify it against the meta-schema. */
     metaSchemaValidation match {
-      case None => ()
+      case None                           => ()
       case Some(expectedValidationResult) =>
         val validator = MetaSchemas.jsonSchemaSchema(version)
         val errors: List[String] = validator.validateFromPathAndGetErrors(jsonOrYamlPath = jsonSchemaFilename)
@@ -126,7 +127,7 @@ object DebtTransSchemaValidator {
       InternalUtils.readJsonNode(jsonOrYamlPath = openApiYamlFilename)
 
     metaSchemaValidation match {
-      case None => ()
+      case None                           => ()
       case Some(expectedValidationResult) =>
         val actualVersion = fullOpenApiNode.path("openapi").asText("")
         val validator = MetaSchemas.yamlSchemaSchema(version = actualVersion)
@@ -284,13 +285,13 @@ object DebtTransSchemaValidator {
   /** Assortment of utilities needed to make the validation work. */
   private object InternalUtils {
 
-    def readJsonNode(jsonOrYamlPath: String)(implicit pos: Position): JsonNode = {
+    def readJsonNode(jsonOrYamlPath: String)(implicit @unused pos: Position): JsonNode = {
       val fileContent = Using(Source.fromFile(jsonOrYamlPath))(_.mkString).get
 
       jsonOrYamlPath.toLowerCase(Locale.ENGLISH) match {
         case s"$_.json"             => jsonToJsonNode(fileContent)
         case s"$_.yaml" | s"$_.yml" => yamlToJsonNode(fileContent)
-        case _ =>
+        case _                      =>
           fail(s"Cannot read file because it doesn't have a json/yaml/yml file extension: $jsonOrYamlPath")
       }
     }

--- a/test/uk/gov/hmrc/timetopayproxy/testutils/schematestutils/impl/MetaSchemas.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/testutils/schematestutils/impl/MetaSchemas.scala
@@ -21,6 +21,8 @@ import org.scalactic.source.Position
 import org.scalatest.Assertions.fail
 import uk.gov.hmrc.timetopayproxy.testutils.schematestutils.impl.DebtTransSchemaValidator.SimpleJsonSchema
 
+import scala.annotation.unused
+
 /** Schemas to validate (arbitrary versions of) other schemas, be it OpenApi YAML, JSON etc.
   *
   * This is needed because schema validation libraries
@@ -29,7 +31,7 @@ import uk.gov.hmrc.timetopayproxy.testutils.schematestutils.impl.DebtTransSchema
   */
 private[impl] object MetaSchemas {
 
-  def yamlSchemaSchema(version: String)(implicit pos: Position): SimpleJsonSchema =
+  def yamlSchemaSchema(version: String)(implicit @unused pos: Position): SimpleJsonSchema =
     version match {
       case s"3.0.$_" =>
         // Downloaded from:
@@ -48,7 +50,7 @@ private[impl] object MetaSchemas {
   /** JSON schema to validate the structure of a JSON schema.
     * @param version what JSON schema version we want this meta-schema to target.
     */
-  def jsonSchemaSchema(version: SpecificationVersion)(implicit pos: Position): SimpleJsonSchema =
+  def jsonSchemaSchema(version: SpecificationVersion)(implicit @unused pos: Position): SimpleJsonSchema =
     version match {
       case SpecificationVersion.DRAFT_4 =>
         new SimpleJsonSchema(

--- a/test/uk/gov/hmrc/timetopayproxy/testutils/schematestutils/impl/RegexFlavourTranslator.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/testutils/schematestutils/impl/RegexFlavourTranslator.scala
@@ -50,9 +50,9 @@ private[impl] object RegexFlavourTranslator {
       logger.warn(
         // Newlines around the text to make it more readable, since it's already got newlines in the middle.
         s"""
-           |Updated OpenAPI regex flavour from EcmaScript to Java: $esPattern ==> $javaPattern
-           |  in $locationContext
-           |""".stripMargin
+          |Updated OpenAPI regex flavour from EcmaScript to Java: $esPattern ==> $javaPattern
+          |  in $locationContext
+          |""".stripMargin
       )
     }
 

--- a/test/uk/gov/hmrc/timetopayproxy/testutils/schematestutils/impl/RegexFlavourTranslatorSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/testutils/schematestutils/impl/RegexFlavourTranslatorSpec.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.timetopayproxy.testutils.schematestutils.impl
 
 import org.scalactic.source.Position
 import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers._
+import org.scalatest.matchers.should.Matchers.*
 
 final class RegexFlavourTranslatorSpec extends AnyFreeSpec {
   "RegexFlavourTranslator" - {

--- a/test/uk/gov/hmrc/timetopayproxy/testutils/schematestutils/impl/SchemaWithComplexAllOfsSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/testutils/schematestutils/impl/SchemaWithComplexAllOfsSpec.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.timetopayproxy.testutils.schematestutils.impl
 
 import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers._
+import org.scalatest.matchers.should.Matchers.*
 import play.api.libs.json.Json
 import uk.gov.hmrc.timetopayproxy.testutils.schematestutils.impl.dummyschemas.SchemaWithComplexAllOfs
 
@@ -27,11 +27,11 @@ class SchemaWithComplexAllOfsSpec extends AnyFreeSpec {
     "should pass if additional properties are not restricted" in {
 
       val allOfJson = """{
-                        |"string": "test1",
-                        |"number": 1,
-                        |"stringArray": ["test1"],
-                        |"numberArray": [1]
-                        |}""".stripMargin
+        |"string": "test1",
+        |"number": 1,
+        |"stringArray": ["test1"],
+        |"numberArray": [1]
+        |}""".stripMargin
 
       val errors =
         SchemaWithComplexAllOfs.openApiSchemaWithoutAdditionalPropertiesRestricted.validateAndGetErrors(
@@ -44,11 +44,11 @@ class SchemaWithComplexAllOfsSpec extends AnyFreeSpec {
     "should produce errors if additional properties are restricted" in {
 
       val allOfJson = """{
-                        |"string": "test1",
-                        |"number": 1,
-                        |"stringArray": ["test1"],
-                        |"numberArray": [1]
-                        |}""".stripMargin
+        |"string": "test1",
+        |"number": 1,
+        |"stringArray": ["test1"],
+        |"numberArray": [1]
+        |}""".stripMargin
 
       val errors =
         SchemaWithComplexAllOfs.openApiSchemaWithAdditionalPropertiesRestricted.validateAndGetErrors(

--- a/test/uk/gov/hmrc/timetopayproxy/testutils/schematestutils/impl/StableStringGeneratorSpec.scala
+++ b/test/uk/gov/hmrc/timetopayproxy/testutils/schematestutils/impl/StableStringGeneratorSpec.scala
@@ -18,14 +18,14 @@ package uk.gov.hmrc.timetopayproxy.testutils.schematestutils.impl
 
 import org.scalactic.source.Position
 import org.scalatest.freespec.AnyFreeSpec
-import org.scalatest.matchers.should.Matchers._
+import org.scalatest.matchers.should.Matchers.*
 import play.api.libs.json.{ JsArray, JsFalse, JsNull, JsNumber, JsObject, JsString, JsTrue, JsValue, Json }
 
 final class StableStringGeneratorSpec extends AnyFreeSpec {
   "StableStringGenerator" - {
 
     ".stableStringForSchemaValidator" - {
-      import StableStringGenerator.{ stableStringForSchemaValidator => stringifier }
+      import StableStringGenerator.stableStringForSchemaValidator as stringifier
 
       /** This here is the main point for the method.
         *
@@ -175,7 +175,7 @@ final class StableStringGeneratorSpec extends AnyFreeSpec {
           val specialCharacterEntries: List[String] = specialCharacterMappings.flatMap(_._2)
           withClue("Validate special character entries.\n\n") {
             specialCharacterEntries.size shouldBe 9
-            specialCharacterEntries.foreach { specialCharacterEntry: String =>
+            specialCharacterEntries.foreach { specialCharacterEntry =>
               withClue(s"Validate special character entry ${JsString(specialCharacterEntry)}") {
                 // Must be titled with a freeform text description, followed by a colon,
                 //   followed by 1-2 UTF-16 code points.


### PR DESCRIPTION
- Update to Scala 3.3
- Update SBT to latest 1.x version
- Modified some library versions that were specifically pulling in Scala 2.13 builds
- Update imports wildcards `_` -> `*`
- Update sequence argument syntax (splat notation) `:_*` -> `*`
- Update Class wildcards `Class[_]` -> `Class[?]`
- Fixed iterators type definitions causing problems in Scala 3 `x.map { it: Int => ...stuff }` becomes `x.map { it => ...stuff }`
- Fixed change in Scala 3 `CaseClass.unapply` method not returning `Some(CaseClass.value)` with a simple lambda `CaseClass.unapply` becomes `x => Some(x.value)`
- Fixed some tests that failed due to ordering in updated Scala 3 internals